### PR TITLE
Use artifactory in release pipeline

### DIFF
--- a/ArtifactoryGenericDownload/downloadArtifacts.js
+++ b/ArtifactoryGenericDownload/downloadArtifacts.js
@@ -6,7 +6,9 @@ const path = require('path');
 const cliDownloadCommand = "rt dl";
 
 function RunTaskCbk(cliPath) {
-    let buildDir = tl.getVariable('Agent.BuildDirectory');
+    let buildDir = tl.getVariable('Agent.BuildDirectory')
+        || tl.getVariable('Agent.ReleaseDirectory')
+        || process.cwd();
     let buildDefinition = tl.getVariable('BUILD.DEFINITIONNAME');
     let buildNumber = tl.getVariable('BUILD_BUILDNUMBER');
     let specPath = path.join(buildDir, "downloadSpec.json");

--- a/ArtifactoryGenericUpload/uploadArtifacts.js
+++ b/ArtifactoryGenericUpload/uploadArtifacts.js
@@ -6,7 +6,9 @@ const path = require('path');
 const cliDownloadCommand = "rt u";
 
 function RunTaskCbk(cliPath) {
-    let buildDir = tl.getVariable('Agent.BuildDirectory');
+    let buildDir = tl.getVariable('Agent.BuildDirectory')
+        || tl.getVariable('Agent.ReleaseDirectory')
+        || process.cwd();
     let buildDefinition = tl.getVariable('BUILD.DEFINITIONNAME');
     let buildNumber = tl.getVariable('BUILD_BUILDNUMBER');
     let specPath = path.join(buildDir, "uploadSpec.json");

--- a/ArtifactoryPromote/artifactoryPromote.js
+++ b/ArtifactoryPromote/artifactoryPromote.js
@@ -5,7 +5,9 @@ const utils = require('jfrog-utils');
 const cliPromoteCommand = "rt bpr";
 
 function RunTaskCbk(cliPath) {
-    let buildDir = tl.getVariable('Agent.BuildDirectory');
+    let buildDir = tl.getVariable('Agent.BuildDirectory')
+        || tl.getVariable('Agent.ReleaseDirectory')
+        || process.cwd();
     let buildDefinition = tl.getVariable('BUILD.DEFINITIONNAME');
     let buildNumber = tl.getVariable('BUILD_BUILDNUMBER');
 

--- a/ArtifactoryPublishBuildInfo/publishBuildInfo.js
+++ b/ArtifactoryPublishBuildInfo/publishBuildInfo.js
@@ -7,7 +7,9 @@ const cliBuildPublishCommand = "rt bp";
 const cliCollectEnvVarsCommand = "rt bce";
 
 function RunTaskCbk(cliPath) {
-    let buildDir = tl.getVariable('Agent.BuildDirectory');
+    let buildDir = tl.getVariable('Agent.BuildDirectory')
+        || tl.getVariable('Agent.ReleaseDirectory')
+        || process.cwd();
     let buildDefinition = tl.getVariable('BUILD.DEFINITIONNAME');
     let buildNumber = tl.getVariable('BUILD_BUILDNUMBER');
 

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestversion": 1,
     "public": true,
     "id": "jfrog-artifactory-vsts-extension",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "name": "JFrog Artifactory",
     "description": "Integrate your JFrog Artifactory with Visual Studio Team Services.",
     "publisher": "JFrog",
@@ -46,6 +46,9 @@
         },
         "support": {
             "uri": "https://www.jfrog.com/support"
+        },
+        "repository": {
+            "uri": "https://github.com/jfrog/artifactory-vsts-extension"
         }
     },
     "branding": {
@@ -73,8 +76,7 @@
                         "endpointUrl": "{{endpoint.url}}/api/plugins",
                         "resourceUrl": "",
                         "resultSelector": "jsonpath:$.values[*]",
-                        "headers": [
-                        ],
+                        "headers": [],
                         "authenticationScheme": null
                     }
                 ],


### PR DESCRIPTION
Hello,

In all tasks there is a line like:
`
let buildDir = tl.getVariable('Agent.BuildDirectory');
`
This code only works when you are executing Artifactory task in Build Pipeline.
To enable download artifacts in Release pipeline or promote builds on release pipeline the task must create "buildDir" like this because in Release definition "Agent.BuildDirectory" variable is **undefined**: 
`
    let buildDir = tl.getVariable('Agent.BuildDirectory')
        || tl.getVariable('Agent.ReleaseDirectory')
        || process.cwd();
`
Some one test this?:
![2018-08-10_11h23_57](https://user-images.githubusercontent.com/907559/43950239-0b0402fa-9c90-11e8-9534-661e1810ed36.png)
Because is documented but it doesn't work...


