### PR TITLE
chore: Add licensing an Repo url

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -35,6 +35,9 @@
     "content": {
         "details": {
             "path": "overview.md"
+        },
+        "license": {
+            "path": "license.txt"
         }
     },
     "links": {
@@ -47,6 +50,10 @@
         "support": {
             "uri": "https://www.jfrog.com/support"
         }
+    },
+    "repository": {
+        "type": "git",
+        "uri": "https://github.com/jfrog/artifactory-vsts-extension"
     },
     "branding": {
         "color": "ffffff",


### PR DESCRIPTION
Porting over from https://github.com/jfrog/jfrog-vso-extension/pull/7
This just makes it easier for people to review code before installing (if they're in that type of org) and adds the license file that is also required in some places.