### PR TITLE
remove leading slashes from build name before querying artifactory api

### DIFF
--- a/tasks/ArtifactoryGenericDownload/Ver2/downloadArtifacts.js
+++ b/tasks/ArtifactoryGenericDownload/Ver2/downloadArtifacts.js
@@ -37,6 +37,9 @@ function performArtifactSourceDownload(cliPath, workDir, artifactoryService, art
     }
     downloadPath = utils.fixWindowsPaths(downloadPath);
 
+    // Remove '/' as Artifactory's api returns build name and number with this prefix.
+    buildName = buildName.replace(/^\//, '');
+
     let cliCommand = utils.cliJoin(cliPath, cliDownloadCommand, utils.quote("*"), utils.quote(downloadPath), "--build=" + utils.quote(buildName + "/" + buildNumber), "--url=" + utils.quote(artifactoryUrl), "--flat=true");
     cliCommand = utils.addArtifactoryCredentials(cliCommand, artifactoryService);
 


### PR DESCRIPTION
Reintroducing leading slash cleanup on buildName.  JFrog cli incorrectly returns no artifacts when the leading slash is not removed from the buildName parameter.