### PR TITLE
Fix conan tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 
 build: off
-stack: node 8
+stack: node 8, python 3.8.2
 skip_tags: true
 environment:
   matrix:

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -77,6 +77,7 @@ function initTests() {
     process.env.JFROG_CLI_REPORT_USAGE = false;
     process.env.JFROG_CLI_OFFER_CONFIG = false;
     process.env.JFROG_CLI_LOG_LEVEL = 'ERROR';
+    process.env.USE_UNSUPPORTED_CONAN_WITH_PYTHON_2 = true;
     tl.setStdStream(devnull());
     tl.setVariable('Agent.WorkFolder', testDataDir);
     tl.setVariable('Agent.TempDirectory', testDataDir);


### PR DESCRIPTION
Disable python2 deprecation prompt on Conan tests
* Use python 3
* Set `USE_UNSUPPORTED_CONAN_WITH_PYTHON_2=true` to allow running tests with Python 2