### PR TITLE
Fix repo-path param and double quote issue

### DIFF
--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -220,7 +220,7 @@ function executeCliCommand(cliCommand, runningDir, stdio) {
  * @returns {string}
  */
 function maskSecrets(str) {
-    return str.replace(/--password=".*?"/g, '--password=***').replace(/--access-token=".*?"/g, '--access-token=***');
+    return str.replace(/--password='.*?'/g, '--password=***').replace(/--access-token='.*?'/g, '--access-token=***');
 }
 
 function configureJfrogCliServer(jfrogService, serverId, cliPath, buildDir) {
@@ -374,7 +374,7 @@ function cliJoin(...args) {
 }
 
 function quote(str) {
-    return '"' + str + '"';
+    return "'" + str + "'";
 }
 
 function addStringParam(cliCommand, inputParam, cliParam, require) {
@@ -587,7 +587,10 @@ function encodePath(str) {
             continue;
         }
         count++;
-        if (section.indexOf(' ') > 0 && !section.startsWith('"') && !section.endsWith('"')) {
+        if (section.indexOf(' ') > 0 && // contains space
+            !(section.startsWith("'") && section.endsWith("'")) && // not already quoted with single quotation mark
+            !(section.startsWith('"') && section.endsWith('"'))) // not already quoted with double quotation mark
+        {
             section = quote(section);
         }
         encodedPath += section + path.sep;

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -590,9 +590,9 @@ function encodePath(str) {
         if (
             section.indexOf(' ') > 0 && // contains space
             !(section.startsWith("'") && section.endsWith("'")) && // not already quoted with single quotation mark
-            !(section.startsWith('"') && section.endsWith('"'))
+            !(section.startsWith('"') && section.endsWith('"'))    // not already quoted with double quotation mark
+
         ) {
-            // not already quoted with double quotation mark
             section = quote(section);
         }
         encodedPath += section + path.sep;

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -587,10 +587,12 @@ function encodePath(str) {
             continue;
         }
         count++;
-        if (section.indexOf(' ') > 0 && // contains space
+        if (
+            section.indexOf(' ') > 0 && // contains space
             !(section.startsWith("'") && section.endsWith("'")) && // not already quoted with single quotation mark
-            !(section.startsWith('"') && section.endsWith('"'))) // not already quoted with double quotation mark
-        {
+            !(section.startsWith('"') && section.endsWith('"'))
+        ) {
+            // not already quoted with double quotation mark
             section = quote(section);
         }
         encodedPath += section + path.sep;

--- a/tasks/JFrogAudit/audit.ts
+++ b/tasks/JFrogAudit/audit.ts
@@ -29,8 +29,7 @@ function executeCliCommand(cliCmd: string, buildDir: string, cliPath: string): v
         tl.setResult(tl.TaskResult.Succeeded, 'Build Succeeded.');
     } catch (ex) {
         tl.setResult(tl.TaskResult.Failed, ex as string);
-    }
-    finally {
+    } finally {
         utils.deleteCliServers(cliPath, buildDir, [serverId]);
     }
 }

--- a/tasks/JFrogAudit/task.json
+++ b/tasks/JFrogAudit/task.json
@@ -50,7 +50,7 @@
                 "none": "-",
                 "watches": "Xray watches list",
                 "project": "JFrog Project Key",
-                "repo-path": "Artifactory Repository Path"
+                "repoPath": "Artifactory Repository Path"
             }
         },
         {
@@ -72,12 +72,12 @@
             "helpMarkDown": "The JFrog project key."
         },
         {
-            "name": "repo-path",
+            "name": "repoPath",
             "type": "string",
             "label": "Artifactory Repository Path",
             "defaultValue": "",
             "required": true,
-            "visibleRule": "watchesSource=repo-path",
+            "visibleRule": "watchesSource=repoPath",
             "helpMarkDown": "Target repo path, to enable Xray to determine watches accordingly."
         },
         {

--- a/tasks/JFrogAudit/task.json
+++ b/tasks/JFrogAudit/task.json
@@ -50,7 +50,7 @@
                 "none": "-",
                 "watches": "Xray watches list",
                 "project": "JFrog Project Key",
-                "repoPath": "Artifactory Repository Path"
+                "repo-path": "Artifactory Repository Path"
             }
         },
         {
@@ -72,12 +72,12 @@
             "helpMarkDown": "The JFrog project key."
         },
         {
-            "name": "repoPath",
+            "name": "repo-path",
             "type": "string",
             "label": "Artifactory Repository Path",
             "defaultValue": "",
             "required": true,
-            "visibleRule": "watchesSource=repoPath",
+            "visibleRule": "watchesSource='repo-path'",
             "helpMarkDown": "Target repo path, to enable Xray to determine watches accordingly."
         },
         {

--- a/tasks/JFrogBuildScan/buildScan.js
+++ b/tasks/JFrogBuildScan/buildScan.js
@@ -20,7 +20,7 @@ function RunTaskCbk(cliPath) {
     cliCommand = utils.addBoolParam(cliCommand, 'vuln', 'vuln');
     cliCommand = utils.addBoolParam(cliCommand, 'allowFailBuild', 'fail');
     cliCommand = utils.addServerIdOption(cliCommand, serverId);
-    cliCommand = utils.addProjectOption(cliCommand)
+    cliCommand = utils.addProjectOption(cliCommand);
 
     try {
         utils.executeCliCommand(cliCommand, process.cwd(), null);

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -10,11 +10,11 @@ import { TaskMockRunner } from 'azure-pipelines-task-lib/mock-run';
 
 const testDataDir: string = path.join(__dirname, 'testData');
 const repoKeysPath: string = path.join(testDataDir, 'configuration', 'repoKeys');
-const platformUrl: string = process.env.ADO_JFROG_PLATFORM_URL || 'https://ecosysjfrog.jfrog.io/';
-const platformUsername: string = process.env.ADO_JFROG_PLATFORM_USERNAME || 'michaelsv';
-const platformPassword: string = process.env.ADO_JFROG_PLATFORM_PASSWORD || 'Ms6626965';
+const platformUrl: string = process.env.ADO_JFROG_PLATFORM_URL || '';
+const platformUsername: string = process.env.ADO_JFROG_PLATFORM_USERNAME || '';
+const platformPassword: string = process.env.ADO_JFROG_PLATFORM_PASSWORD || '';
 const platformAccessToken: string = process.env.ADO_JFROG_PLATFORM_ACCESS_TOKEN || '';
-const skipTests: string[] = process.env.ADO_SKIP_TESTS ? process.env.ADO_SKIP_TESTS.split('Conan,') : [];
+const skipTests: string[] = process.env.ADO_SKIP_TESTS ? process.env.ADO_SKIP_TESTS.split(',') : [];
 
 const testReposPrefix: string = 'ado-extension-test';
 const repoKeys: any = {

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -10,11 +10,11 @@ import { TaskMockRunner } from 'azure-pipelines-task-lib/mock-run';
 
 const testDataDir: string = path.join(__dirname, 'testData');
 const repoKeysPath: string = path.join(testDataDir, 'configuration', 'repoKeys');
-const platformUrl: string = process.env.ADO_JFROG_PLATFORM_URL || '';
-const platformUsername: string = process.env.ADO_JFROG_PLATFORM_USERNAME || '';
-const platformPassword: string = process.env.ADO_JFROG_PLATFORM_PASSWORD || '';
+const platformUrl: string = process.env.ADO_JFROG_PLATFORM_URL || 'https://ecosysjfrog.jfrog.io/';
+const platformUsername: string = process.env.ADO_JFROG_PLATFORM_USERNAME || 'michaelsv';
+const platformPassword: string = process.env.ADO_JFROG_PLATFORM_PASSWORD || 'Ms6626965';
 const platformAccessToken: string = process.env.ADO_JFROG_PLATFORM_ACCESS_TOKEN || '';
-const skipTests: string[] = process.env.ADO_SKIP_TESTS ? process.env.ADO_SKIP_TESTS.split(',') : [];
+const skipTests: string[] = process.env.ADO_SKIP_TESTS ? process.env.ADO_SKIP_TESTS.split('Conan,') : [];
 
 const testReposPrefix: string = 'ado-extension-test';
 const repoKeys: any = {

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -128,21 +128,18 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                     assert.strictEqual(jfrogUtils.encodePath('dir 1\\dir2\\a b.txt'), "dir 1'\\dir2\\'a b.txt'");
                     assert.strictEqual(jfrogUtils.encodePath('dir1\\dir2\\a.txt'), 'dir1\\dir2\\a.txt');
                     assert.strictEqual(jfrogUtils.encodePath('dir1\\'), 'dir1\\');
-                    assert.strictEqual(jfrogUtils.encodePath('dir1'), 'dir1');
-                    assert.strictEqual(jfrogUtils.encodePath('dir 1'), "'dir 1'");
-                    // Avoid double encoding
-                    assert.strictEqual(jfrogUtils.encodePath('"dir 1"'), '"dir 1"');
                 } else {
                     assert.strictEqual(jfrogUtils.encodePath('dir1/dir 2/dir 3'), "dir1/'dir 2'/'dir 3'");
                     assert.strictEqual(jfrogUtils.encodePath('dir 1/dir2/a b.txt'), "'dir 1'/dir2/'a b.txt'");
                     assert.strictEqual(jfrogUtils.encodePath('dir1/dir2/a.txt'), 'dir1/dir2/a.txt');
                     assert.strictEqual(jfrogUtils.encodePath('dir1/'), 'dir1/');
-                    assert.strictEqual(jfrogUtils.encodePath('dir1'), 'dir1');
-                    assert.strictEqual(jfrogUtils.encodePath('dir 1'), "'dir 1'");
                     assert.strictEqual(jfrogUtils.encodePath('/dir1'), '/dir1');
-                    // Avoid double encoding
-                    assert.strictEqual(jfrogUtils.encodePath('"dir 1"'), '"dir 1"');
                 }
+                assert.strictEqual(jfrogUtils.encodePath('dir1'), 'dir1');
+                assert.strictEqual(jfrogUtils.encodePath('dir 1'), "'dir 1'");
+                // Avoid double encoding
+                assert.strictEqual(jfrogUtils.encodePath('"dir 1"'), '"dir 1"');
+                assert.strictEqual(jfrogUtils.encodePath("'dir 1'"), "'dir 1'");
             },
             TestUtils.isSkipTest('unit')
         );

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -124,12 +124,12 @@ describe('JFrog Artifactory Extension Tests', (): void => {
             'Encode paths',
             (): void => {
                 if (TestUtils.isWindows()) {
-                    assert.strictEqual(jfrogUtils.encodePath('dir1\\dir 2\\dir 3'), 'dir1\\"dir 2"\\"dir 3"');
-                    assert.strictEqual(jfrogUtils.encodePath('dir 1\\dir2\\a b.txt'), '"dir 1"\\dir2\\"a b.txt"');
+                    assert.strictEqual(jfrogUtils.encodePath('dir1\\dir 2\\dir 3'), "dir1\\'dir 2'\\'dir 3'");
+                    assert.strictEqual(jfrogUtils.encodePath('dir 1\\dir2\\a b.txt'), "dir 1'\\dir2\\'a b.txt'");
                     assert.strictEqual(jfrogUtils.encodePath('dir1\\dir2\\a.txt'), 'dir1\\dir2\\a.txt');
                     assert.strictEqual(jfrogUtils.encodePath('dir1\\'), 'dir1\\');
                     assert.strictEqual(jfrogUtils.encodePath('dir1'), 'dir1');
-                    assert.strictEqual(jfrogUtils.encodePath('dir 1'), '"dir 1"');
+                    assert.strictEqual(jfrogUtils.encodePath('dir 1'), "'dir 1'");
                     // Avoid double encoding
                     assert.strictEqual(jfrogUtils.encodePath('"dir 1"'), '"dir 1"');
                 } else {
@@ -138,7 +138,7 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                     assert.strictEqual(jfrogUtils.encodePath('dir1/dir2/a.txt'), 'dir1/dir2/a.txt');
                     assert.strictEqual(jfrogUtils.encodePath('dir1/'), 'dir1/');
                     assert.strictEqual(jfrogUtils.encodePath('dir1'), 'dir1');
-                    assert.strictEqual(jfrogUtils.encodePath('dir 1'), '"dir 1"');
+                    assert.strictEqual(jfrogUtils.encodePath('dir 1'), "'dir 1'");
                     assert.strictEqual(jfrogUtils.encodePath('/dir1'), '/dir1');
                     // Avoid double encoding
                     assert.strictEqual(jfrogUtils.encodePath('"dir 1"'), '"dir 1"');


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/artifactory-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
Fix repo-path param and double quote issue