### PR TITLE
Fix Azure Server verification fail on visible rule

### DIFF
--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -221,7 +221,7 @@ function executeCliCommand(cliCommand, runningDir, stdio) {
  */
 function maskSecrets(str) {
     if (isWindows()) {
-       return str.replace(/--password=".*?"/g, '--password=***').replace(/--access-token=".*?"/g, '--access-token=***');
+        return str.replace(/--password=".*?"/g, '--password=***').replace(/--access-token=".*?"/g, '--access-token=***');
     }
     return str.replace(/--password='.*?'/g, '--password=***').replace(/--access-token='.*?'/g, '--access-token=***');
 }
@@ -377,7 +377,7 @@ function cliJoin(...args) {
 }
 
 function quote(str) {
-    if (isWindows()){
+    if (isWindows()) {
         return '"' + str + '"';
     }
     return "'" + str + "'";
@@ -596,8 +596,7 @@ function encodePath(str) {
         if (
             section.indexOf(' ') > 0 && // contains space
             !(section.startsWith("'") && section.endsWith("'")) && // not already quoted with single quotation mark
-            !(section.startsWith('"') && section.endsWith('"'))    // not already quoted with double quotation mark
-
+            !(section.startsWith('"') && section.endsWith('"')) // not already quoted with double quotation mark
         ) {
             section = quote(section);
         }

--- a/tasks/JFrogAudit/audit.ts
+++ b/tasks/JFrogAudit/audit.ts
@@ -17,8 +17,15 @@ function RunTaskCbk(cliPath: string): void {
 
     // Add watches source if provided.
     const watchesSource: string = tl.getInput('watchesSource', false) || '';
-    if (watchesSource !== 'none') {
-        auditCommand = utils.addStringParam(auditCommand, watchesSource, watchesSource, true);
+    switch (watchesSource) {
+        // Having a '-' in a param name is failing verification on Azure Server (TFS).
+        case 'repoPath':
+            auditCommand = utils.addStringParam(auditCommand, 'repoPath', 'repo-path', true);
+            break;
+        case 'watches':
+        case 'project':
+            auditCommand = utils.addStringParam(auditCommand, watchesSource, watchesSource, true);
+            break;
     }
     executeCliCommand(auditCommand, sourcePath, cliPath);
 }

--- a/tasks/JFrogAudit/audit.ts
+++ b/tasks/JFrogAudit/audit.ts
@@ -19,6 +19,7 @@ function RunTaskCbk(cliPath: string): void {
     const watchesSource: string = tl.getInput('watchesSource', false) || '';
     switch (watchesSource) {
         // Having a dash (-) in a param name in a visible rule is failing verification on Azure Server (TFS).
+        // For that reason we do not use a dash in repo-path, and handle this param separately (not passing the option blindly to the CLI).
         case 'repoPath':
             auditCommand = utils.addStringParam(auditCommand, 'repoPath', 'repo-path', true);
             break;

--- a/tasks/JFrogAudit/audit.ts
+++ b/tasks/JFrogAudit/audit.ts
@@ -18,7 +18,7 @@ function RunTaskCbk(cliPath: string): void {
     // Add watches source if provided.
     const watchesSource: string = tl.getInput('watchesSource', false) || '';
     switch (watchesSource) {
-        // Having a '-' in a param name is failing verification on Azure Server (TFS).
+        // Having a dash (-) in a param name in a visible rule is failing verification on Azure Server (TFS).
         case 'repoPath':
             auditCommand = utils.addStringParam(auditCommand, 'repoPath', 'repo-path', true);
             break;

--- a/tasks/JFrogAudit/task.json
+++ b/tasks/JFrogAudit/task.json
@@ -50,7 +50,7 @@
                 "none": "-",
                 "watches": "Xray watches list",
                 "project": "JFrog Project Key",
-                "repo-path": "Artifactory Repository Path"
+                "repoPath": "Artifactory Repository Path"
             }
         },
         {
@@ -72,12 +72,12 @@
             "helpMarkDown": "The JFrog project key."
         },
         {
-            "name": "repo-path",
+            "name": "repoPath",
             "type": "string",
             "label": "Artifactory Repository Path",
             "defaultValue": "",
             "required": true,
-            "visibleRule": "watchesSource='repo-path'",
+            "visibleRule": "watchesSource=repoPath",
             "helpMarkDown": "Target repo path, to enable Xray to determine watches accordingly."
         },
         {

--- a/tests/resources/moveCopyDelete/copy.js
+++ b/tests/resources/moveCopyDelete/copy.js
@@ -7,9 +7,9 @@ let inputs = {
     fileSpec: JSON.stringify({
         files: [
             {
-                pattern: testUtils.getRemoteTestDir(testUtils.getRepoKeys().repo1, TEST_NAME) + "*${action}*",
-                target: testUtils.getRemoteTestDir(testUtils.getRepoKeys().repo1, TEST_NAME) + "new${action}.in",
-                flat: "true"
+                pattern: testUtils.getRemoteTestDir(testUtils.getRepoKeys().repo1, TEST_NAME) + '*${action}*',
+                target: testUtils.getRemoteTestDir(testUtils.getRepoKeys().repo1, TEST_NAME) + 'new${action}.in',
+                flat: 'true'
             }
         ]
     }),

--- a/tests/resources/moveCopyDelete/delete.js
+++ b/tests/resources/moveCopyDelete/delete.js
@@ -7,7 +7,7 @@ let inputs = {
     fileSpec: JSON.stringify({
         files: [
             {
-                pattern: testUtils.getRemoteTestDir(testUtils.getRepoKeys().repo1, TEST_NAME) + "*${action}.in"
+                pattern: testUtils.getRemoteTestDir(testUtils.getRepoKeys().repo1, TEST_NAME) + '*${action}.in'
             }
         ]
     }),

--- a/tests/resources/moveCopyDelete/move.js
+++ b/tests/resources/moveCopyDelete/move.js
@@ -7,9 +7,9 @@ let inputs = {
     fileSpec: JSON.stringify({
         files: [
             {
-                pattern: testUtils.getRemoteTestDir(testUtils.getRepoKeys().repo1, TEST_NAME) + "*${action}*",
-                target: testUtils.getRemoteTestDir(testUtils.getRepoKeys().repo1, TEST_NAME) + "${action}.in",
-                flat: "true"
+                pattern: testUtils.getRemoteTestDir(testUtils.getRepoKeys().repo1, TEST_NAME) + '*${action}*',
+                target: testUtils.getRemoteTestDir(testUtils.getRepoKeys().repo1, TEST_NAME) + '${action}.in',
+                flat: 'true'
             }
         ]
     }),

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -415,13 +415,17 @@ export function getRemoteReleaseBundle(bundleName: string, bundleVersion: string
 }
 
 export function deleteReleaseBundle(bundleName: string, bundleVersion: string): void {
-    syncRequest.default('POST', stripTrailingSlash(platformUrl) + '/distribution/api/v1/distribution/' + bundleName + '/' + bundleVersion + '/delete', {
-        headers: {
-            Authorization: getAuthorizationHeaderValue(),
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ dry_run: false, distribution_rules: [{ site_name: '*' }], on_success: 'delete' })
-    });
+    syncRequest.default(
+        'POST',
+        stripTrailingSlash(platformUrl) + '/distribution/api/v1/distribution/' + bundleName + '/' + bundleVersion + '/delete',
+        {
+            headers: {
+                Authorization: getAuthorizationHeaderValue(),
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ dry_run: false, distribution_rules: [{ site_name: '*' }], on_success: 'delete' })
+        }
+    );
 }
 
 export function getAuthorizationHeaderValue(): string {

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -54,7 +54,7 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                             ' --user=' +
                             jfrogUtils.quote(process.env.ADO_ARTIFACTORY_USERNAME || '') +
                             ' --password=' +
-                            jfrogUtils.quote("SUPER_SECRET"),
+                            jfrogUtils.quote('SUPER_SECRET'),
                         TestUtils.testDataDir,
                         ['']
                     );
@@ -63,7 +63,7 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                 }
                 assert.ok(retVal !== '', 'An exception should have been caught');
                 process.env.ADO_ARTIFACTORY_PASSWORD = oldPassword;
-                assert.ok(!retVal.toString().includes("SUPER_SECRET"), 'Output contains password');
+                assert.ok(!retVal.toString().includes('SUPER_SECRET'), 'Output contains password');
             },
             TestUtils.isSkipTest('unit')
         );
@@ -394,7 +394,8 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                 assertFiles(path.join(testDir, 'expectedFiles'), testDir);
             },
             TestUtils.isSkipTest('generic')
-        );    });
+        );
+    });
 
     describe('Publish Build Info Tests', (): void => {
         runSyncTest(


### PR DESCRIPTION
Having a dash (`-`) in a visible rule is failing Azure Server (TFS)'s verification when installing the extension.
