### PR TITLE
Improve sync deletes flow

### DIFF
--- a/tasks/JFrogGenericArtifacts/runGenericArtifacts.js
+++ b/tasks/JFrogGenericArtifacts/runGenericArtifacts.js
@@ -68,9 +68,9 @@ function handleGenericUpload(cliPath, workDir) {
     cliCommand = utils.addBoolParam(cliCommand, 'preserveSymlinks', 'symlinks');
     cliCommand = addDebParam(cliCommand);
 
-    let syncDeletes = tl.getBoolInput('syncDeletesRemote');
-    if (syncDeletes) {
-        cliCommand = utils.addStringParam(cliCommand, 'syncDeletesPathRemote', 'sync-deletes', false);
+    let syncDeletesPath = tl.getInput('syncDeletesPathRemote', false);
+    if (syncDeletesPath) {
+        cliCommand = utils.cliJoin(cliCommand, '--' + 'sync-deletes' + '=' + utils.quote(syncDeletesPath));
     }
     performGenericTask(cliCommand, cliPath, workDir);
 }
@@ -85,9 +85,9 @@ function handleGenericDownload(cliPath, workDir) {
 
     cliCommand = utils.addBoolParam(cliCommand, 'validateSymlinks', 'validate-symlinks');
 
-    let syncDeletes = tl.getBoolInput('syncDeletesLocal');
-    if (syncDeletes) {
-        cliCommand = utils.addStringParam(cliCommand, 'syncDeletesPathLocal', 'sync-deletes', false);
+    let syncDeletesPath = tl.getInput('syncDeletesPathLocal', false);
+    if (syncDeletesPath) {
+        cliCommand = utils.cliJoin(cliCommand, '--' + 'sync-deletes' + '=' + utils.quote(syncDeletesPath));
     }
     performGenericTask(cliCommand, cliPath, workDir);
 }

--- a/tasks/JFrogGenericArtifacts/task.json
+++ b/tasks/JFrogGenericArtifacts/task.json
@@ -376,7 +376,7 @@
             "required": false,
             "groupName": "advanced",
             "visibleRule": "command=Upload",
-            "helpMarkDown": "If you'd like to sync dependencies after the upload, set a specific path in Artifactory. Leave empty otherwise.\nIf set, after the upload completes, this path will include only the artifacts uploaded during this upload operation. The other files under this path will be deleted."
+            "helpMarkDown": "If you'd like to sync artifacts after the upload, set a specific path in Artifactory. Leave empty otherwise.\nIf set, after the upload completes, this path will include only the artifacts uploaded during this upload operation. The other files under this path will be deleted."
         }
     ],
     "execution": {

--- a/tasks/JFrogGenericArtifacts/task.json
+++ b/tasks/JFrogGenericArtifacts/task.json
@@ -312,23 +312,14 @@
             "helpMarkDown": "Validation is done by comparing file's sha1.\nApplicable to files and not directories."
         },
         {
-            "name": "syncDeletesLocal",
-            "type": "boolean",
-            "label": "Sync and delete files from the local file system",
-            "defaultValue": "false",
-            "required": false,
-            "groupName": "advanced",
-            "visibleRule": "command=Download",
-            "helpMarkDown": "Select if you'd like to set a specific local file system path, under which to sync dependencies after the download.\nAfter the download, this path will include only the dependencies downloaded during this download operation. The other files under this path will be deleted."
-        },
-        {
             "name": "syncDeletesPathLocal",
             "type": "string",
-            "label": "Local sync path",
+            "label": "Path to sync and delete files from in the local file system",
             "defaultValue": "",
             "required": false,
             "groupName": "advanced",
-            "visibleRule": "syncDeletesLocal=true"
+            "visibleRule": "command=Download",
+            "helpMarkDown": "If you'd like to sync dependencies after the download, set a specific local file system path. Leave empty otherwise.\nIf set, after the download completes, this path will include only the dependencies downloaded during this download operation. The other files under this path will be deleted."
         },
         {
             "name": "preserveSymlinks",
@@ -378,23 +369,14 @@
             "visibleRule": "setDebianProps=true"
         },
         {
-            "name": "syncDeletesRemote",
-            "type": "boolean",
-            "label": "Sync and delete files from a path in Artifactory",
-            "defaultValue": "false",
-            "required": false,
-            "groupName": "advanced",
-            "visibleRule": "command=Upload",
-            "helpMarkDown": "Select if you'd like to set a specific path in Artifactory, under which to sync artifacts after the upload.\nAfter the upload, this path will include only the artifacts uploaded during this upload operation. The other files under this path will be deleted."
-        },
-        {
             "name": "syncDeletesPathRemote",
             "type": "string",
-            "label": "Sync path",
+            "label": "Path to sync and delete files from in Artifactory",
             "defaultValue": "",
             "required": false,
             "groupName": "advanced",
-            "visibleRule": "syncDeletesRemote=true"
+            "visibleRule": "command=Upload",
+            "helpMarkDown": "If you'd like to sync dependencies after the upload, set a specific path in Artifactory. Leave empty otherwise.\nIf set, after the upload completes, this path will include only the artifacts uploaded during this upload operation. The other files under this path will be deleted."
         }
     ],
     "execution": {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Removes the redundant checkbox, users may now provide a path to enable, or leave empty to disable.
The checkbox (boolean param) is confusing when using YAML configuration.

From:
![image](https://user-images.githubusercontent.com/43318887/159463008-6666f8a0-de25-4539-bc91-1df5d7ec0475.png)

To:
![image](https://user-images.githubusercontent.com/43318887/159462608-a1293af0-ddd5-49d9-b0ee-e3ffd4e140ca.png)
