### PR TITLE
Use correct architecture identifier for 64 bit linux.

### DIFF
--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -561,6 +561,8 @@ function getArchitecture() {
     switch (process.arch) {
         case 'amd64':
             return 'linux-amd64';
+        case 'x64':
+            return 'linux-amd64';
         case 'arm64':
             return 'linux-arm64';
         case 'arm':

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -559,8 +559,6 @@ function getArchitecture() {
         return 'mac-386';
     }
     switch (process.arch) {
-        case 'amd64':
-            return 'linux-amd64';
         case 'x64':
             return 'linux-amd64';
         case 'arm64':


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
'amd64' is not (and never was) in the list of possible values: 'arm', 'arm64', 'ia32', 'mips', 'mipsel', 'ppc', 'ppc64', 's390', 's390x', 'x32', and 'x64'. (https://nodejs.org/docs/latest-v16.x/api/process.html#processarch)