### PR TITLE
Support providing the JDK in Maven task

### DIFF
--- a/jfrog-tasks-utils/utils.d.ts
+++ b/jfrog-tasks-utils/utils.d.ts
@@ -38,5 +38,7 @@ declare module '@jfrog/tasks-utils' {
     export function taskDefaultCleanup(cliPath: string, workDir: string, serverIdsArray: string[]): string;
     export function appendBuildFlagsToCliCommand(cliCommand: string): string;
     export function isToolExists(tool: string): boolean;
+    export function removeExtractorsDownloadVariables(cliPath: string, workDir: string);
+    export function configureArtifactoryCliServer(artifactoryService: string, serverId: string, cliPath: string, buildDir: string);
     export { taskSelectedCliVersionEnv };
 }

--- a/tasks/JFrogMaven/.gitignore
+++ b/tasks/JFrogMaven/.gitignore
@@ -1,0 +1,4 @@
+# Ignore ts outputs
+mavenBuild.js.map
+mavenBuild.d.ts
+mavenBuild.js

--- a/tasks/JFrogMaven/mavenBuild.ts
+++ b/tasks/JFrogMaven/mavenBuild.ts
@@ -1,17 +1,19 @@
-const tl = require('azure-pipelines-task-lib/task');
-const utils = require('@jfrog/tasks-utils/utils.js');
-const execSync = require('child_process').execSync;
+import * as tl from 'azure-pipelines-task-lib/task';
+import * as utils from '@jfrog/tasks-utils/utils.js';
+import * as javaCommons from 'azure-pipelines-tasks-java-common/java-common';
+import { execSync, ExecSyncOptionsWithStringEncoding } from 'child_process';
 
-const cliMavenCommand = 'mvn';
-const mavenConfigCommand = 'mvnc';
-let serverIdDeployer;
-let serverIdResolver;
+const cliMavenCommand: string = 'mvn';
+const mavenConfigCommand: string = 'mvnc';
+let serverIdDeployer: string;
+let serverIdResolver: string;
 
 utils.executeCliTask(RunTaskCbk);
 
-function RunTaskCbk(cliPath) {
+function RunTaskCbk(cliPath: string): void {
+    setJdkHome();
     checkAndSetMavenHome();
-    let workDir = tl.getVariable('System.DefaultWorkingDirectory');
+    let workDir: string | undefined = tl.getVariable('System.DefaultWorkingDirectory');
     if (!workDir) {
         tl.setResult(tl.TaskResult.Failed, 'Failed getting default working directory.');
         return;
@@ -21,25 +23,25 @@ function RunTaskCbk(cliPath) {
     try {
         createMavenConfigFile(cliPath, workDir);
     } catch (ex) {
-        tl.setResult(tl.TaskResult.Failed, ex);
+        tl.setResult(tl.TaskResult.Failed, ex as string);
         cleanup(cliPath, workDir);
         return;
     }
 
     // Running Maven command
-    let pomFile = tl.getInput('mavenPOMFile');
-    let goalsAndOptions = tl.getInput('goals');
+    let pomFile: string | undefined = tl.getInput('mavenPOMFile') || '';
+    let goalsAndOptions: string | undefined = tl.getInput('goals') || '';
     goalsAndOptions = utils.cliJoin(goalsAndOptions, '-f', pomFile);
-    let options = tl.getInput('options');
+    let options: string = tl.getInput('options') || '';
     if (options) {
         goalsAndOptions = utils.cliJoin(goalsAndOptions, options);
     }
-    let mavenCommand = utils.cliJoin(cliPath, cliMavenCommand, goalsAndOptions);
+    let mavenCommand: string = utils.cliJoin(cliPath, cliMavenCommand, goalsAndOptions);
     mavenCommand = utils.appendBuildFlagsToCliCommand(mavenCommand);
     try {
-        utils.executeCliCommand(mavenCommand, workDir, null);
+        utils.executeCliCommand(mavenCommand, workDir, undefined);
     } catch (ex) {
-        tl.setResult(tl.TaskResult.Failed, ex);
+        tl.setResult(tl.TaskResult.Failed, ex as string);
     } finally {
         cleanup(cliPath, workDir);
     }
@@ -47,31 +49,52 @@ function RunTaskCbk(cliPath) {
     tl.setResult(tl.TaskResult.Succeeded, 'Build Succeeded.');
 }
 
-function checkAndSetMavenHome() {
-    let m2HomeEnvVar = tl.getVariable('M2_HOME');
+function setJdkHome(): void {
+    let javaHomeSelection: string | undefined = tl.getInput('javaHomeSelection', true);
+    let javaHome: string | undefined;
+    if (javaHomeSelection == 'JDKVersion') {
+        // Set JAVA_HOME to the specified JDK version (default, 1.7, 1.8, etc.)
+        tl.debug('Using the specified JDK version to find and set JAVA_HOME');
+        let jdkVersion: string = tl.getInput('jdkVersion') || '';
+        let jdkArchitecture: string = tl.getInput('jdkArchitecture') || '';
+        if (jdkVersion != 'default') {
+            javaHome = javaCommons.findJavaHome(jdkVersion, jdkArchitecture);
+        }
+    } else {
+        // Set JAVA_HOME to the path specified by the user
+        tl.debug('Setting JAVA_HOME to the path specified by user input');
+        javaHome = tl.getPathInput('jdkUserInputPath', true, true);
+    }
+
+    // Set JAVA_HOME as determined above (if different than default)
+    if (javaHome) {
+        console.log('The Java home location: ' + javaHome);
+        tl.setVariable('JAVA_HOME', javaHome);
+    }
+}
+
+function checkAndSetMavenHome(): void {
+    let m2HomeEnvVar: string | undefined = tl.getVariable('M2_HOME');
     if (!m2HomeEnvVar) {
         console.log('M2_HOME is not defined. Retrieving Maven home using mvn --version.');
         // The M2_HOME environment variable is not defined.
         // Since Maven installation can be located in different locations,
         // depending on the installation type and the OS (for example: For Mac with brew install: /usr/local/Cellar/maven/{version}/libexec or Ubuntu with debian: /usr/share/maven),
         // we need to grab the location using the mvn --version command
-        let mvnCommand = 'mvn --version';
-        let res = execSync(mvnCommand);
-        let mavenHomeLine = String.fromCharCode
-            .apply(null, res)
-            .split('\n')[1]
-            .trim();
-        let mavenHome = mavenHomeLine.split(' ')[2];
+        let mvnCommand: string = 'mvn --version';
+        let res: string = execSync(mvnCommand, { encoding: 'utf-8' } as ExecSyncOptionsWithStringEncoding);
+        let mavenHomeLine: string = res.split('\n')[1].trim();
+        let mavenHome: string = mavenHomeLine.split(' ')[2];
         console.log('The Maven home location: ' + mavenHome);
         process.env['M2_HOME'] = mavenHome;
     }
 }
 
-function createMavenConfigFile(cliPath, buildDir) {
-    let cliCommand = utils.cliJoin(cliPath, mavenConfigCommand);
+function createMavenConfigFile(cliPath: string, buildDir: string) {
+    let cliCommand: string = utils.cliJoin(cliPath, mavenConfigCommand);
 
     // Configure resolver server, throws on failure.
-    let artifactoryResolver = tl.getInput('artifactoryResolverService');
+    let artifactoryResolver: string | undefined = tl.getInput('artifactoryResolverService');
     if (artifactoryResolver) {
         serverIdResolver = utils.assembleUniqueServerId('maven_resolver');
         utils.configureArtifactoryCliServer(artifactoryResolver, serverIdResolver, cliPath, buildDir);
@@ -83,14 +106,14 @@ function createMavenConfigFile(cliPath, buildDir) {
     }
 
     // Configure deployer server, skip if missing. This allows user to resolve dependencies from artifactory without deployment.
-    let artifactoryDeployer = tl.getInput('artifactoryDeployService');
+    let artifactoryDeployer: string = tl.getInput('artifactoryDeployService') || '';
     if (artifactoryDeployer) {
         serverIdDeployer = utils.assembleUniqueServerId('maven_deployer');
         utils.configureArtifactoryCliServer(artifactoryDeployer, serverIdDeployer, cliPath, buildDir);
         cliCommand = utils.cliJoin(cliCommand, '--server-id-deploy=' + utils.quote(serverIdDeployer));
         cliCommand = utils.addStringParam(cliCommand, 'targetDeployReleaseRepo', 'repo-deploy-releases', true);
         cliCommand = utils.addStringParam(cliCommand, 'targetDeploySnapshotRepo', 'repo-deploy-snapshots', true);
-        let filterDeployedArtifacts = tl.getBoolInput('filterDeployedArtifacts');
+        let filterDeployedArtifacts: boolean | undefined = tl.getBoolInput('filterDeployedArtifacts');
         if (filterDeployedArtifacts) {
             cliCommand = utils.addStringParam(cliCommand, 'includePatterns', 'include-patterns', false);
             cliCommand = utils.addStringParam(cliCommand, 'excludePatterns', 'exclude-patterns', false);
@@ -100,19 +123,19 @@ function createMavenConfigFile(cliPath, buildDir) {
     }
     // Execute cli.
     try {
-        utils.executeCliCommand(cliCommand, buildDir, null);
+        utils.executeCliCommand(cliCommand, buildDir, undefined);
     } catch (ex) {
-        tl.setResult(tl.TaskResult.Failed, ex);
+        tl.setResult(tl.TaskResult.Failed, ex as string);
     }
 }
 
-function cleanup(cliPath, workDir) {
+function cleanup(cliPath: string, workDir: string): void {
     // Delete servers.
     utils.taskDefaultCleanup(cliPath, workDir, [serverIdDeployer, serverIdResolver]);
     // Remove extractor variables.
     try {
         utils.removeExtractorsDownloadVariables(cliPath, workDir);
     } catch (removeVariablesException) {
-        tl.setResult(tl.TaskResult.Failed, removeVariablesException);
+        tl.setResult(tl.TaskResult.Failed, removeVariablesException as string);
     }
 }

--- a/tasks/JFrogMaven/package.json
+++ b/tasks/JFrogMaven/package.json
@@ -10,6 +10,7 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "@jfrog/tasks-utils": "file:../../jfrog-tasks-utils/jfrog-tasks-utils-1.0.0.tgz"
+        "@jfrog/tasks-utils": "file:../../jfrog-tasks-utils/jfrog-tasks-utils-1.0.0.tgz",
+        "azure-pipelines-tasks-java-common": "~2.201.0"
     }
 }

--- a/tasks/JFrogMaven/task.json
+++ b/tasks/JFrogMaven/task.json
@@ -6,18 +6,13 @@
     "author": "JFrog",
     "helpMarkDown": "[More Information](https://www.jfrog.com/confluence/display/JFROG/JFrog+Azure+DevOps+Extension#JFrogAzureDevOpsExtension-TriggeringMavenBuilds)",
     "category": "Utility",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
+    "visibility": ["Build", "Release"],
     "version": {
         "Major": "1",
         "Minor": "3",
         "Patch": "0"
     },
-    "demands": [
-        "maven"
-    ],
+    "demands": ["maven"],
     "minimumAgentVersion": "1.89.0",
     "instanceNameFormat": "JFrog Maven",
     "groups": [
@@ -30,14 +25,17 @@
             "name": "deployer",
             "displayName": "Deploy artifacts to Artifactory",
             "isExpanded": true
+        },
+        {
+            "name": "advanced",
+            "displayName": "Advanced",
+            "isExpanded": false
         }
     ],
     "inputs": [
         {
             "name": "mavenPOMFile",
-            "aliases": [
-                "mavenPomFile"
-            ],
+            "aliases": ["mavenPomFile"],
             "type": "filePath",
             "label": "Maven POM file",
             "defaultValue": "pom.xml",
@@ -200,6 +198,67 @@
             "required": false,
             "visibleRule": "collectBuildInfo == true",
             "helpMarkDown": "Select to include environment variables in the published build info."
+        },
+        {
+            "name": "javaHomeSelection",
+            "aliases": ["javaHomeOption"],
+            "type": "radio",
+            "label": "Set JAVA_HOME by",
+            "required": true,
+            "groupName": "advanced",
+            "defaultValue": "JDKVersion",
+            "helpMarkDown": "Sets JAVA_HOME either by selecting a JDK version that will be discovered during builds or by manually entering a JDK path.",
+            "options": {
+                "JDKVersion": "JDK Version",
+                "Path": "Path"
+            }
+        },
+        {
+            "name": "jdkVersion",
+            "aliases": ["jdkVersionOption"],
+            "type": "pickList",
+            "label": "JDK version",
+            "required": false,
+            "groupName": "advanced",
+            "defaultValue": "default",
+            "helpMarkDown": "Will attempt to discover the path to the selected JDK version and set JAVA_HOME accordingly.",
+            "visibleRule": "javaHomeSelection = JDKVersion",
+            "options": {
+                "default": "default",
+                "1.17": "JDK 17",
+                "1.11": "JDK 11",
+                "1.10": "JDK 10 (out of support)",
+                "1.9": "JDK 9 (out of support)",
+                "1.8": "JDK 8",
+                "1.7": "JDK 7",
+                "1.6": "JDK 6 (out of support)"
+            }
+        },
+        {
+            "name": "jdkUserInputPath",
+            "aliases": ["jdkDirectory"],
+            "type": "string",
+            "label": "JDK path",
+            "required": true,
+            "groupName": "advanced",
+            "defaultValue": "",
+            "helpMarkDown": "Sets JAVA_HOME to the given path.",
+            "visibleRule": "javaHomeSelection = Path"
+        },
+        {
+            "name": "jdkArchitecture",
+            "aliases": ["jdkArchitectureOption"],
+            "type": "pickList",
+            "label": "JDK architecture",
+            "defaultValue": "x64",
+            "required": false,
+            "helpMarkDown": "Optionally supply the architecture (x86, x64) of the JDK.",
+            "visibleRule": "jdkVersion != default",
+            "groupName": "advanced",
+            "options": {
+                "x86": "x86",
+                "x64": "x64"
+            }
         }
     ],
     "dataSourceBindings": [


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Resolves #161 

* Allow selecting the JDK version in the same way that the default Maven job does:
![image](https://user-images.githubusercontent.com/11367982/206914224-2e20d9bb-d89d-4472-9398-f645ca123eb2.png)
* Migrate Maven task to Typescipt
