### PR TITLE
Remove demand for "gradle" in the Gradle task

### DIFF
--- a/tasks/JFrogGradle/task.json
+++ b/tasks/JFrogGradle/task.json
@@ -6,18 +6,13 @@
     "author": "JFrog",
     "helpMarkDown": "[More Information](https://www.jfrog.com/confluence/display/JFROG/JFrog+Azure+DevOps+Extension#JFrogAzureDevOpsExtension-TriggeringGradleBuilds)",
     "category": "Utility",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
+    "visibility": ["Build", "Release"],
     "version": {
         "Major": "1",
         "Minor": "4",
         "Patch": "1"
     },
-    "demands": [
-        "gradle"
-    ],
+    "demands": [],
     "minimumAgentVersion": "1.89.0",
     "instanceNameFormat": "JFrog Gradle",
     "groups": [


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

It is not necessarily needed to have Gradle installed in the agent since there is a good chance that there is a Gradle wrapper in the project.
This PR removes this limitation.