### PR TITLE
Add 'workingDirectory' parameter to the Generic Artifacts task

### DIFF
--- a/tasks/JFrogGenericArtifacts/runGenericArtifacts.js
+++ b/tasks/JFrogGenericArtifacts/runGenericArtifacts.js
@@ -12,8 +12,15 @@ const cliDeleteArtifactsCommand = 'rt del';
 let serverId;
 
 function RunTaskCbk(cliPath) {
-    let workDir = tl.getPathInput('workingDirectory') ?? tl.getVariable('System.DefaultWorkingDirectory');
-    if (!workDir) {
+    let defaultWorkDir = tl.getVariable('System.DefaultWorkingDirectory');
+    if (!defaultWorkDir) {
+        tl.setResult(tl.TaskResult.Failed, 'Failed getting default working directory.');
+        return;
+    }
+
+    let inputWorkingDirectory = tl.getInput('workingDirectory', false);
+    let workDir = utils.determineCliWorkDir(defaultWorkDir, inputWorkingDirectory);
+    if (!fs.existsSync(workDir) || !fs.lstatSync(workDir).isDirectory()) {
         tl.setResult(tl.TaskResult.Failed, 'Failed getting working directory.');
         return;
     }

--- a/tasks/JFrogGenericArtifacts/runGenericArtifacts.js
+++ b/tasks/JFrogGenericArtifacts/runGenericArtifacts.js
@@ -12,9 +12,9 @@ const cliDeleteArtifactsCommand = 'rt del';
 let serverId;
 
 function RunTaskCbk(cliPath) {
-    let workDir = tl.getVariable('System.DefaultWorkingDirectory');
+    let workDir = tl.getPathInput('workingDirectory') ?? tl.getVariable('System.DefaultWorkingDirectory');
     if (!workDir) {
-        tl.setResult(tl.TaskResult.Failed, 'Failed getting default working directory.');
+        tl.setResult(tl.TaskResult.Failed, 'Failed getting working directory.');
         return;
     }
 

--- a/tasks/JFrogGenericArtifacts/task.json
+++ b/tasks/JFrogGenericArtifacts/task.json
@@ -379,10 +379,17 @@
             "name": "syncDeletesPathRemote",
             "type": "string",
             "label": "Path to sync and delete files from in Artifactory",
-            "defaultValue": "",
             "required": false,
             "groupName": "advancedUpload",
             "helpMarkDown": "If you'd like to sync artifacts after the upload, set a specific path in Artifactory. Leave empty otherwise.\nIf set, after the upload completes, this path will include only the artifacts uploaded during this upload operation. The other files under this path will be deleted."
+        },
+        {
+            "name": "workingDirectory",
+            "type": "filePath",
+            "label": "Working Directory",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Current working directory to use. Empty is the root of the repo (build) or artifacts (release), which is $(System.DefaultWorkingDirectory)"
         }
     ],
     "execution": {

--- a/tasks/JFrogGenericArtifacts/task.json
+++ b/tasks/JFrogGenericArtifacts/task.json
@@ -389,7 +389,7 @@
             "label": "Working Directory",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Current working directory to use. Empty is the root of the repo (build) or artifacts (release), which is $(System.DefaultWorkingDirectory)"
+            "helpMarkDown": "The working directory where the command will run. When empty, the value of '$(System.DefaultWorkingDirectory)' is used."
         }
     ],
     "execution": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,6 +8,7 @@
     "main": "testUtils.ts",
     "dependencies": {
         "@jfrog/tasks-utils": "file:../jfrog-tasks-utils/jfrog-tasks-utils-1.0.0.tgz",
+        "@jfrog/test-utils": "file:",
         "azure-pipelines-task-lib": "^3.1.10",
         "fs-extra": "^7.0.1",
         "js-yaml": "^3.13.1",

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,7 +8,6 @@
     "main": "testUtils.ts",
     "dependencies": {
         "@jfrog/tasks-utils": "file:../jfrog-tasks-utils/jfrog-tasks-utils-1.0.0.tgz",
-        "@jfrog/test-utils": "file:",
         "azure-pipelines-task-lib": "^3.1.10",
         "fs-extra": "^7.0.1",
         "js-yaml": "^3.13.1",

--- a/tests/resources/uploadAndDownloadWorkingDirectory/download.js
+++ b/tests/resources/uploadAndDownloadWorkingDirectory/download.js
@@ -1,0 +1,25 @@
+const testUtils = require('../../testUtils');
+const path = require('path');
+
+const TEST_NAME = path.basename(__dirname);
+
+let inputs = {
+    command: 'Download',
+    fileSpec: JSON.stringify({
+        files: [
+            {
+                pattern: testUtils.getRemoteTestDir(testUtils.getRepoKeys().repo1, TEST_NAME),
+                target: './subdir/',
+                flat: 'true'
+            }
+        ]
+    }),
+    failNoOp: true,
+    dryRun: false,
+    insecureTls: false,
+    validateSymlinks: false,
+    specSource: 'taskConfiguration',
+    workingDirectory: testUtils.getLocalTestDir(TEST_NAME)
+};
+
+testUtils.runArtifactoryTask(testUtils.generic, {}, inputs);

--- a/tests/resources/uploadAndDownloadWorkingDirectory/files/subdir/a.in
+++ b/tests/resources/uploadAndDownloadWorkingDirectory/files/subdir/a.in
@@ -1,0 +1,1 @@
+I find your lack of faith disturbing

--- a/tests/resources/uploadAndDownloadWorkingDirectory/files/subdir/b.in
+++ b/tests/resources/uploadAndDownloadWorkingDirectory/files/subdir/b.in
@@ -1,0 +1,1 @@
+I’ve got a bad feeling about this.

--- a/tests/resources/uploadAndDownloadWorkingDirectory/files/subdir/c.in
+++ b/tests/resources/uploadAndDownloadWorkingDirectory/files/subdir/c.in
@@ -1,0 +1,1 @@
+It’s a trap!

--- a/tests/resources/uploadAndDownloadWorkingDirectory/upload.js
+++ b/tests/resources/uploadAndDownloadWorkingDirectory/upload.js
@@ -1,0 +1,23 @@
+const testUtils = require('../../testUtils');
+
+const TEST_NAME = testUtils.getTestName(__dirname);
+
+let inputs = {
+    command: 'Upload',
+    fileSpec: JSON.stringify({
+        files: [
+            {
+                pattern: './subdir/*',
+                target: testUtils.getRemoteTestDir(testUtils.getRepoKeys().repo1, TEST_NAME)
+            }
+        ]
+    }),
+    failNoOp: true,
+    dryRun: false,
+    insecureTls: false,
+    preserveSymlinks: false,
+    specSource: 'taskConfiguration',
+    workingDirectory: testUtils.getTestLocalFilesDir(__dirname)
+};
+
+testUtils.runArtifactoryTask(testUtils.generic, {}, inputs);

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -311,6 +311,17 @@ describe('JFrog Artifactory Extension Tests', (): void => {
         );
 
         runSyncTest(
+            'Upload and download with working directory',
+            (): void => {
+                const testDir: string = 'uploadAndDownloadWithWorkingDirectory';
+                mockTask(testDir, 'upload');
+                mockTask(testDir, 'download');
+                assertFiles(path.join(testDir, 'files'), testDir);
+            },
+            TestUtils.isSkipTest('generic')
+        );
+
+        runSyncTest(
             'Upload and dry-run download',
             (): void => {
                 const testDir: string = 'uploadAndDryRunDownload';


### PR DESCRIPTION
- Allows overriding the default working directory

- [x] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
