### PR TITLE
Update JFrog CLI macOs and Linux architectures

### DIFF
--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -560,14 +560,19 @@ function compareVersionTokens(version1Token, version2Token) {
 }
 
 function getArchitecture() {
-    let platform = process.platform;
+    const platform = process.platform;
     if (platform.startsWith('win')) {
+        // Windows architecture:
         return 'windows-amd64';
     }
+    const arch = process.arch;
     if (platform.includes('darwin')) {
-        return 'mac-386';
+        // macOS architecture:
+        return arch === 'arm64' ? 'mac-arm64' : 'mac-386';
     }
-    switch (process.arch) {
+
+    // linux architecture:
+    switch (arch) {
         case 'x64':
             return 'linux-amd64';
         case 'arm64':
@@ -576,8 +581,11 @@ function getArchitecture() {
             return 'linux-arm';
         case 's390x':
             return 'linux-s390x';
+        case 'ppc64':
+            return 'linux-ppc64';
+        default:
+            return 'linux-386';
     }
-    return 'linux-386';
 }
 
 function getCliExecutableName() {

--- a/tests/resources/collectIssues/collect.js
+++ b/tests/resources/collectIssues/collect.js
@@ -2,7 +2,7 @@ const testUtils = require('../../testUtils');
 const yaml = require('js-yaml');
 const path = require('path');
 const TEST_NAME = testUtils.getTestName(__dirname);
-const CUSTOM_WORKING_DIR = "customDir"
+const CUSTOM_WORKING_DIR = 'customDir';
 
 const configYaml = {
     version: 1,

--- a/tests/resources/collectIssues/collectFromFile.js
+++ b/tests/resources/collectIssues/collectFromFile.js
@@ -2,7 +2,7 @@ const testUtils = require('../../testUtils');
 const path = require('path');
 const TEST_NAME = testUtils.getTestName(__dirname);
 const configPath = path.join(testUtils.testDataDir, TEST_NAME, 'config.yaml');
-const CUSTOM_WORKING_DIR = "customDir"
+const CUSTOM_WORKING_DIR = 'customDir';
 
 let inputs = {
     buildName: 'Collect issues from file',

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -6,13 +6,13 @@ import * as mocha from 'mocha';
 import * as path from 'path';
 import * as syncRequest from 'sync-request';
 import * as TestUtils from './testUtils';
+import {platformDockerDomain} from './testUtils';
 import * as toolLib from 'azure-pipelines-tool-lib/tool';
 import * as assert from 'assert';
 import * as os from 'os';
 import conanUtils from '../tasks/JFrogConan/conanUtils';
-import { Tunnel } from 'node-tunnel';
-import { execSync } from 'child_process';
-import { platformDockerDomain } from './testUtils';
+import {Tunnel} from 'node-tunnel';
+import {execSync} from 'child_process';
 
 let tasksOutput: string;
 
@@ -153,10 +153,10 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                 const arch: string = jfrogUtils.getArchitecture();
                 switch (os.type()) {
                     case 'Linux':
-                        assert.ok(arch.startsWith('linux'));
+                        assert.ok(arch.startsWith('linux-'));
                         break;
                     case 'Darwin':
-                        assert.strictEqual(arch, 'mac-386');
+                        assert.ok(arch.startsWith('mac-'));
                         break;
                     case 'Windows_NT':
                         assert.strictEqual(arch, 'windows-amd64');


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
Added 2 archs:
- 'arm64' >  'mac-arm64'
- 'ppc64' > 'linux-ppc64'