### PR TITLE
Fix Maven home parsing for paths with whitespaces

### DIFF
--- a/tasks/JFrogMaven/mavenBuild.ts
+++ b/tasks/JFrogMaven/mavenBuild.ts
@@ -84,9 +84,14 @@ function checkAndSetMavenHome(): void {
         let mvnCommand: string = 'mvn --version';
         let res: string = execSync(mvnCommand, { encoding: 'utf-8' } as ExecSyncOptionsWithStringEncoding);
         let mavenHomeLine: string = res.split('\n')[1].trim();
-        let mavenHome: string = mavenHomeLine.split(' ')[2];
-        console.log('The Maven home location: ' + mavenHome);
-        process.env['M2_HOME'] = mavenHome;
+        let regexMatch: RegExpMatchArray | null = mavenHomeLine.match('^Maven\\shome:\\s(.+)');
+        if (regexMatch) {
+            let mavenHomePath: string = regexMatch[1];
+            console.log('The Maven home location: ' + mavenHomePath);
+            process.env['M2_HOME'] = mavenHomePath;
+        } else {
+            console.log('Couldn\'t retrieve Maven home path using "mvn --version" command. Received output: ' + res);
+        }
     }
 }
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
For example: `Maven home: C:\Program Files\Maven\apache-maven-3.9.1`

following https://github.com/jfrog/jfrog-azure-devops-extension/issues/412