### PR TITLE
Allow to bypass the indexer-app archive limits on docker scan

### DIFF
--- a/tasks/JFrogDocker/docker.ts
+++ b/tasks/JFrogDocker/docker.ts
@@ -31,6 +31,11 @@ function RunTaskCbk(cliPath: string): void {
             if (tl.getBoolInput('allowFailBuild', false)) {
                 cliCommand = utils.addBoolParam(cliCommand, 'allowFailBuild', 'fail');
             }
+
+            if (tl.getBoolInput('allowBypassArchiveLimits', false)) {
+                cliCommand = utils.addBoolParam(cliCommand, 'allowBypassArchiveLimits', 'bypass-archive-limits');
+            }
+
             // Add watches source if provided.
             const watchesSource: string = tl.getInput('watchesSource', false) ?? '';
             switch (watchesSource) {

--- a/tasks/JFrogDocker/task.json
+++ b/tasks/JFrogDocker/task.json
@@ -129,6 +129,15 @@
             "visibleRule": "command = Scan && watchesSource!=none"
         },
         {
+            "name": "allowBypassArchiveLimits",
+            "type": "boolean",
+            "label": "Bypass archive limits",
+            "defaultValue": "false",
+            "required": true,
+            "helpMarkDown": "Allow to bypass the indexer-app archive limits, defaults to false.",
+            "visibleRule": "command = Scan && watchesSource!=none"
+        },
+        {
             "name": "collectBuildInfo",
             "type": "boolean",
             "label": "Collect build info",


### PR DESCRIPTION
Allow to bypass the indexer-app archive limits on docker scan