### PR TITLE
OIDC Authentication Support

### DIFF
--- a/jfrog-tasks-utils/package.json
+++ b/jfrog-tasks-utils/package.json
@@ -8,9 +8,11 @@
     "main": "utils",
     "typings": "utils.d.ts",
     "dependencies": {
+        "azure-devops-node-api": "^13.0.0",
         "azure-pipelines-task-lib": "4.5.0",
         "azure-pipelines-tool-lib": "2.0.6",
         "azure-pipelines-tasks-java-common": "^2.219.1",
+        "node-fetch": "2.0.0",
         "typed-rest-client": "^1.8.11"
     },
     "scripts": {

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -195,16 +195,16 @@ async function getAccessTokenWithOIDForEndpoint(endpoint_name, provider_name, en
     const oidcClaims = JSON.parse(Buffer.from(oidcTokenParts[1], 'base64').toString());
 
     // Log the OIDC token claims so users know how to configure AWS
-    console.log("OIDC Token Subject: ", oidcClaims.sub);
+    console.log('OIDC Token Subject: ', oidcClaims.sub);
     console.log(`OIDC Token Claims: {"sub": "${oidcClaims.sub}"}`);
-    console.log("OIDC Token Issuer (Provider URL): ", oidcClaims.iss);
-    console.log("OIDC Token Audience: ", oidcClaims.aud);
+    console.log('OIDC Token Issuer (Provider URL): ', oidcClaims.iss);
+    console.log('OIDC Token Audience: ', oidcClaims.aud);
 
     const artifactoryTokenRequestBoth = {
-        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
-        "subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
-        "subject_token": adoToken,
-        "provider_name": provider_name
+        grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+        subject_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+        subject_token: adoToken,
+        provider_name: provider_name,
     };
 
     let token_server = auth_server ? auth_server : endpoint_server;
@@ -212,7 +212,7 @@ async function getAccessTokenWithOIDForEndpoint(endpoint_name, provider_name, en
     let response = await fetch(`${token_server}/access/api/v1/oidc/token`, {
         method: 'post',
         body: JSON.stringify(artifactoryTokenRequestBoth),
-        headers: { 'Content-Type': 'application/json' }
+        headers: { 'Content-Type': 'application/json' },
     });
     const data = await response.json();
     console.log(`JFrog access token acquired, expires in ${(data.expires_in / 60).toFixed(2)} minutes.`);
@@ -221,12 +221,12 @@ async function getAccessTokenWithOIDForEndpoint(endpoint_name, provider_name, en
 }
 
 async function getOidcTokenForEndpoint(endpoint_name) {
-    const jobId = getVariableRequired("System.JobId");
-    const planId = getVariableRequired("System.PlanId");
-    const projectId = getVariableRequired("System.TeamProjectId");
-    const hub = getVariableRequired("System.HostType");
-    const uri = getVariableRequired("System.CollectionUri");
-    const token = getVariableRequired("System.AccessToken");
+    const jobId = getVariableRequired('System.JobId');
+    const planId = getVariableRequired('System.PlanId');
+    const projectId = getVariableRequired('System.TeamProjectId');
+    const hub = getVariableRequired('System.HostType');
+    const uri = getVariableRequired('System.CollectionUri');
+    const token = getVariableRequired('System.AccessToken');
 
     const auth = azNodeLib.getBasicHandler('', token);
     const connection = new azNodeLib.WebApi(uri, auth);
@@ -239,12 +239,12 @@ async function getOidcTokenForEndpoint(endpoint_name) {
 }
 
 function getVariableRequired(name) {
-    const variable = tl.getVariable(name)
+    const variable = tl.getVariable(name);
     if (!variable) {
-        throw new Error(`Required variable '${name}' returned undefined!`)
+        throw new Error(`Required variable '${name}' returned undefined!`);
     }
 
-    return variable
+    return variable;
 }
 
 function generateDownloadCliErrorMessage(downloadUrl, cliVersion) {

--- a/tasks/JFrogAudit/task.json
+++ b/tasks/JFrogAudit/task.json
@@ -12,8 +12,8 @@
     ],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "demands": [],
     "minimumAgentVersion": "1.89.0",

--- a/tasks/JFrogBuildPromotion/task.json
+++ b/tasks/JFrogBuildPromotion/task.json
@@ -13,8 +13,8 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",
     "instanceNameFormat": "JFrog Build Promotion",

--- a/tasks/JFrogBuildScan/task.json
+++ b/tasks/JFrogBuildScan/task.json
@@ -13,8 +13,8 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",
     "instanceNameFormat": "JFrog Build Scan",

--- a/tasks/JFrogCliV2/task.json
+++ b/tasks/JFrogCliV2/task.json
@@ -12,8 +12,8 @@
     ],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "demands": [],
     "minimumAgentVersion": "1.89.0",

--- a/tasks/JFrogCollectIssues/task.json
+++ b/tasks/JFrogCollectIssues/task.json
@@ -13,8 +13,8 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",
     "instanceNameFormat": "JFrog Collect Build Issues",

--- a/tasks/JFrogConan/task.json
+++ b/tasks/JFrogConan/task.json
@@ -13,8 +13,8 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",
     "instanceNameFormat": "Conan $(conanCommand)",

--- a/tasks/JFrogDiscardBuilds/task.json
+++ b/tasks/JFrogDiscardBuilds/task.json
@@ -13,8 +13,8 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",
     "instanceNameFormat": "JFrog Discard Builds",

--- a/tasks/JFrogDistribution/task.json
+++ b/tasks/JFrogDistribution/task.json
@@ -12,8 +12,8 @@
     ],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "demands": [],
     "minimumAgentVersion": "1.83.0",

--- a/tasks/JFrogDocker/task.json
+++ b/tasks/JFrogDocker/task.json
@@ -12,8 +12,8 @@
     ],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "demands": [],
     "minimumAgentVersion": "1.89.0",

--- a/tasks/JFrogDotnet/task.json
+++ b/tasks/JFrogDotnet/task.json
@@ -12,8 +12,8 @@
     ],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "demands": [],
     "minimumAgentVersion": "2.115.0",

--- a/tasks/JFrogGenericArtifacts/runGenericArtifacts.js
+++ b/tasks/JFrogGenericArtifacts/runGenericArtifacts.js
@@ -12,7 +12,7 @@ const cliCopyCommand = 'rt cp';
 const cliDeleteArtifactsCommand = 'rt del';
 let serverId;
 
-function RunTaskCbk(cliPath) {
+async function RunTaskCbk(cliPath) {
     let defaultWorkDir = tl.getVariable('System.DefaultWorkingDirectory');
     if (!defaultWorkDir) {
         tl.setResult(tl.TaskResult.Failed, 'Failed getting default working directory.');
@@ -29,7 +29,7 @@ function RunTaskCbk(cliPath) {
     // The 'connection' input parameter is used by Artifact Source Download and cannot be renamed due to Azure limitations.
     let artifactoryService = tl.getInput('connection', true);
     serverId = utils.assembleUniqueServerId('generic');
-    utils.configureArtifactoryCliServer(artifactoryService, serverId, cliPath, workDir);
+    await utils.configureArtifactoryCliServer(artifactoryService, serverId, cliPath, workDir);
 
     // Decide if the task runs as generic or artifact-source download.
     let definition = tl.getInput('definition', false);

--- a/tasks/JFrogGenericArtifacts/task.json
+++ b/tasks/JFrogGenericArtifacts/task.json
@@ -13,8 +13,8 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",
     "instanceNameFormat": "JFrog Generic Artifacts $(command)",

--- a/tasks/JFrogGo/task.json
+++ b/tasks/JFrogGo/task.json
@@ -12,8 +12,8 @@
     ],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "demands": [],
     "minimumAgentVersion": "1.91.0",

--- a/tasks/JFrogGradle/gradleBuild.js
+++ b/tasks/JFrogGradle/gradleBuild.js
@@ -8,7 +8,7 @@ let serverIdResolver;
 
 utils.executeCliTask(RunTaskCbk);
 
-function RunTaskCbk(cliPath) {
+async function RunTaskCbk(cliPath) {
     utils.setJdkHomeForJavaTasks();
     let workDir = getWorkDir();
     try {
@@ -16,7 +16,7 @@ function RunTaskCbk(cliPath) {
             tl.setResult(tl.TaskResult.Failed, 'Failed getting default working directory.');
             return;
         }
-        executeGradleConfig(cliPath, workDir);
+        await executeGradleConfig(cliPath, workDir);
         executeGradle(cliPath, workDir);
     } catch (ex) {
         tl.setResult(tl.TaskResult.Failed, ex);
@@ -45,7 +45,7 @@ function getWorkDir() {
  * @param cliPath - Path to JFrog CLI
  * @param workDir - Gradle project directory
  */
-function executeGradleConfig(cliPath, workDir) {
+async function executeGradleConfig(cliPath, workDir) {
     // Build the cli config command.
     let cliCommand = utils.cliJoin(cliPath, gradleConfigCommand);
 
@@ -53,7 +53,7 @@ function executeGradleConfig(cliPath, workDir) {
     let artifactoryResolver = tl.getInput('artifactoryResolverService');
     if (artifactoryResolver) {
         serverIdResolver = utils.assembleUniqueServerId('gradle_resolver');
-        utils.configureArtifactoryCliServer(artifactoryResolver, serverIdResolver, cliPath, workDir);
+        await utils.configureArtifactoryCliServer(artifactoryResolver, serverIdResolver, cliPath, workDir);
         cliCommand = utils.cliJoin(cliCommand, '--server-id-resolve=' + utils.quote(serverIdResolver));
     } else {
         console.log('Resolution from Artifactory is not configured');
@@ -63,7 +63,7 @@ function executeGradleConfig(cliPath, workDir) {
     let artifactoryDeployer = tl.getInput('artifactoryDeployerService');
     if (artifactoryDeployer) {
         serverIdDeployer = utils.assembleUniqueServerId('gradle_deployer');
-        utils.configureArtifactoryCliServer(artifactoryDeployer, serverIdDeployer, cliPath, workDir);
+        await utils.configureArtifactoryCliServer(artifactoryDeployer, serverIdDeployer, cliPath, workDir);
         cliCommand = utils.cliJoin(cliCommand, '--server-id-deploy=' + utils.quote(serverIdDeployer));
     }
 

--- a/tasks/JFrogGradle/task.json
+++ b/tasks/JFrogGradle/task.json
@@ -12,8 +12,8 @@
     ],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "demands": [],
     "minimumAgentVersion": "1.89.0",

--- a/tasks/JFrogMaven/mavenBuild.ts
+++ b/tasks/JFrogMaven/mavenBuild.ts
@@ -8,7 +8,7 @@ let serverIdResolver: string;
 
 utils.executeCliTask(RunTaskCbk);
 
-function RunTaskCbk(cliPath: string): void {
+async function RunTaskCbk(cliPath: string): Promise<void> {
     utils.setJdkHomeForJavaTasks();
     checkAndSetMavenHome();
     const workDir: string | undefined = tl.getVariable('System.DefaultWorkingDirectory');
@@ -19,7 +19,7 @@ function RunTaskCbk(cliPath: string): void {
 
     // Create Maven config file.
     try {
-        createMavenConfigFile(cliPath, workDir);
+        await createMavenConfigFile(cliPath, workDir);
     } catch (ex) {
         tl.setResult(tl.TaskResult.Failed, ex as string);
         cleanup(cliPath, workDir);
@@ -70,14 +70,14 @@ function checkAndSetMavenHome(): void {
     }
 }
 
-function createMavenConfigFile(cliPath: string, buildDir: string) {
+async function createMavenConfigFile(cliPath: string, buildDir: string) {
     let cliCommand: string = utils.cliJoin(cliPath, mavenConfigCommand);
 
     // Configure resolver server, throws on failure.
     const artifactoryResolver: string | undefined = tl.getInput('artifactoryResolverService');
     if (artifactoryResolver) {
         serverIdResolver = utils.assembleUniqueServerId('maven_resolver');
-        utils.configureArtifactoryCliServer(artifactoryResolver, serverIdResolver, cliPath, buildDir);
+        await utils.configureArtifactoryCliServer(artifactoryResolver, serverIdResolver, cliPath, buildDir);
         cliCommand = utils.cliJoin(cliCommand, '--server-id-resolve=' + utils.quote(serverIdResolver));
         cliCommand = utils.addStringParam(cliCommand, 'targetResolveReleaseRepo', 'repo-resolve-releases', true);
         cliCommand = utils.addStringParam(cliCommand, 'targetResolveSnapshotRepo', 'repo-resolve-snapshots', true);
@@ -89,7 +89,7 @@ function createMavenConfigFile(cliPath: string, buildDir: string) {
     const artifactoryDeployer: string = tl.getInput('artifactoryDeployService') ?? '';
     if (artifactoryDeployer) {
         serverIdDeployer = utils.assembleUniqueServerId('maven_deployer');
-        utils.configureArtifactoryCliServer(artifactoryDeployer, serverIdDeployer, cliPath, buildDir);
+        await utils.configureArtifactoryCliServer(artifactoryDeployer, serverIdDeployer, cliPath, buildDir);
         cliCommand = utils.cliJoin(cliCommand, '--server-id-deploy=' + utils.quote(serverIdDeployer));
         cliCommand = utils.addStringParam(cliCommand, 'targetDeployReleaseRepo', 'repo-deploy-releases', true);
         cliCommand = utils.addStringParam(cliCommand, 'targetDeploySnapshotRepo', 'repo-deploy-snapshots', true);

--- a/tasks/JFrogMaven/task.json
+++ b/tasks/JFrogMaven/task.json
@@ -12,8 +12,8 @@
     ],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "demands": [
         "maven"

--- a/tasks/JFrogNpm/task.json
+++ b/tasks/JFrogNpm/task.json
@@ -12,8 +12,8 @@
     ],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "demands": [
         "npm"

--- a/tasks/JFrogNuget/task.json
+++ b/tasks/JFrogNuget/task.json
@@ -12,8 +12,8 @@
     ],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "demands": [],
     "minimumAgentVersion": "2.115.0",

--- a/tasks/JFrogPip/task.json
+++ b/tasks/JFrogPip/task.json
@@ -12,8 +12,8 @@
     ],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "demands": [],
     "minimumAgentVersion": "1.89.0",

--- a/tasks/JFrogPublishBuildInfo/task.json
+++ b/tasks/JFrogPublishBuildInfo/task.json
@@ -13,8 +13,8 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "minimumAgentVersion": "1.83.0",
     "instanceNameFormat": "JFrog Publish Build Info",

--- a/tasks/JFrogToolsInstaller/task.json
+++ b/tasks/JFrogToolsInstaller/task.json
@@ -12,8 +12,8 @@
     ],
     "version": {
         "Major": "1",
-        "Minor": "9",
-        "Patch": "4"
+        "Minor": "10",
+        "Patch": "0"
     },
     "demands": [],
     "minimumAgentVersion": "1.89.0",

--- a/tasks/JFrogToolsInstaller/toolsInstaller.js
+++ b/tasks/JFrogToolsInstaller/toolsInstaller.js
@@ -1,9 +1,9 @@
 const tl = require('azure-pipelines-task-lib/task');
 const utils = require('@jfrog/tasks-utils/utils.js');
 
-InstallCliAndExecuteCliTask(RunTaskCbk);
+await InstallCliAndExecuteCliTask(RunTaskCbk);
 
-function InstallCliAndExecuteCliTask(RunTaskCbk) {
+async function InstallCliAndExecuteCliTask(RunTaskCbk) {
     let artifactoryService = tl.getInput('artifactoryConnection', true);
     let artifactoryUrl = tl.getEndpointUrl(artifactoryService, false);
     let cliInstallationRepo = tl.getInput('cliInstallationRepo', true);
@@ -21,7 +21,7 @@ function InstallCliAndExecuteCliTask(RunTaskCbk) {
     // Set the requested CLI version env to download it now, and to use in succeeding tasks.
     tl.setVariable(utils.pipelineRequestedCliVersionEnv, cliVersion);
     let downloadUrl = utils.buildCliArtifactoryDownloadUrl(artifactoryUrl, cliInstallationRepo, cliVersion);
-    let authHandlers = utils.createAuthHandlers(artifactoryService);
+    let authHandlers = await utils.createAuthHandlers(artifactoryService);
     utils.executeCliTask(RunTaskCbk, cliVersion, downloadUrl, authHandlers);
 }
 

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "public": true,
     "id": "jfrog-azure-devops-extension",
-    "version": "2.9.4",
+    "version": "2.10.0",
     "name": "JFrog",
     "description": "Integrate your JFrog Platform with Visual Studio Team Services.",
     "publisher": "JFrog",
@@ -147,6 +147,37 @@
                                     "isRequired": true,
                                     "dataType": "string"
                                 }
+                            },
+                            {
+                                "type": "ms.vss-endpoint.endpoint-auth-scheme-none",
+                                "displayName": "Azure DevOps OIDC (Services only)",
+                                "properties": {
+                                    "isVerifiable": "False"
+                                },
+                                "inputDescriptors": [
+                                    {
+                                        "id": "providerName",
+                                        "name": "Provider Name",
+                                        "description": "The OIDC \"Provider Name\" configured in JFrog Platform. The OIDC provider & token claim details are provided in the build log output of any task using this connection.",
+                                        "inputMode": "textbox",
+                                        "isConfidential": false,
+                                        "validation": {
+                                            "isRequired": true,
+                                            "dataType": "string"
+                                        }
+                                    },
+                                    {
+                                        "id": "authServer",
+                                        "name": "Auth Server",
+                                        "description": "The access token will be obtained from this server but operations will use the server URL from above. May be required if using edge nodes.",
+                                        "inputMode": "textbox",
+                                        "isConfidential": false,
+                                        "validation": {
+                                            "isRequired": false,
+                                            "dataType": "string"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }
@@ -234,6 +265,37 @@
                                 }
                             }
                         ]
+                    },
+                    {
+                        "type": "ms.vss-endpoint.endpoint-auth-scheme-none",
+                        "displayName": "Azure DevOps OIDC (Services only)",
+                        "properties": {
+                            "isVerifiable": "False"
+                        },
+                        "inputDescriptors": [
+                            {
+                                "id": "providerName",
+                                "name": "Provider Name",
+                                "description": "The OIDC \"Provider Name\" configured in JFrog Platform. The OIDC provider & token claim details are provided in the build log output of any task using this connection.",
+                                "inputMode": "textbox",
+                                "isConfidential": false,
+                                "validation": {
+                                    "isRequired": true,
+                                    "dataType": "string"
+                                }
+                            },
+                            {
+                                "id": "authServer",
+                                "name": "Auth Server",
+                                "description": "The access token will be obtained from this server but operations will use the server URL from above. May be required if using edge nodes.",
+                                "inputMode": "textbox",
+                                "isConfidential": false,
+                                "validation": {
+                                    "isRequired": false,
+                                    "dataType": "string"
+                                }
+                            }
+                        ]
                     }
                 ]
             }
@@ -309,6 +371,37 @@
                                 }
                             }
                         ]
+                    },
+                    {
+                        "type": "ms.vss-endpoint.endpoint-auth-scheme-none",
+                        "displayName": "Azure DevOps OIDC (Services only)",
+                        "properties": {
+                            "isVerifiable": "False"
+                        },
+                        "inputDescriptors": [
+                            {
+                                "id": "providerName",
+                                "name": "Provider Name",
+                                "description": "The OIDC \"Provider Name\" configured in JFrog Platform. The OIDC provider & token claim details are provided in the build log output of any task using this connection.",
+                                "inputMode": "textbox",
+                                "isConfidential": false,
+                                "validation": {
+                                    "isRequired": true,
+                                    "dataType": "string"
+                                }
+                            },
+                            {
+                                "id": "authServer",
+                                "name": "Auth Server",
+                                "description": "The access token will be obtained from this server but operations will use the server URL from above. May be required if using edge nodes.",
+                                "inputMode": "textbox",
+                                "isConfidential": false,
+                                "validation": {
+                                    "isRequired": false,
+                                    "dataType": "string"
+                                }
+                            }
+                        ]
                     }
                 ]
             }
@@ -380,6 +473,37 @@
                                 "isConfidential": true,
                                 "validation": {
                                     "isRequired": true,
+                                    "dataType": "string"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "ms.vss-endpoint.endpoint-auth-scheme-none",
+                        "displayName": "Azure DevOps OIDC (Services only)",
+                        "properties": {
+                            "isVerifiable": "False"
+                        },
+                        "inputDescriptors": [
+                            {
+                                "id": "providerName",
+                                "name": "Provider Name",
+                                "description": "The OIDC \"Provider Name\" configured in JFrog Platform. The OIDC provider & token claim details are provided in the build log output of any task using this connection.",
+                                "inputMode": "textbox",
+                                "isConfidential": false,
+                                "validation": {
+                                    "isRequired": true,
+                                    "dataType": "string"
+                                }
+                            },
+                            {
+                                "id": "authServer",
+                                "name": "Auth Server",
+                                "description": "The access token will be obtained from this server but operations will use the server URL from above. May be required if using edge nodes.",
+                                "inputMode": "textbox",
+                                "isConfidential": false,
+                                "validation": {
+                                    "isRequired": false,
                                     "dataType": "string"
                                 }
                             }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

This adds OIDC Authentication support allowing passwordless authentication between Azure DevOps Service and the JFrog Platform. It's the Azure DevOps equivalent of the [GitHub Actions OIDC integration workflow](https://jfrog.com/help/r/jfrog-platform-administration-documentation/github-actions-oidc-integration-workflow). Essentially in JFrog an OIDC provider is configured for each Azure DevOps organization that needs to authenticate, and an identity mapping in that OIDC provider is created for each service connection that authenticates into the JFrog Platform. The Azure DevOps integration isn't quite as user friendly to configure, the details for the configuration are currently printed in the task logs but if a good how-to document was created then users could refer to that for the values.

I have tested this against a few JFrog tasks but not all of them. I'm not sure if there's a good way to add automated tests for these changes but I'm working on setting up a pipeline to run all the tasks with both OIDC and tokens to make sure it's all working and I didn't miss an async or await somewhere.


Related Issue: #494 