### PR TITLE
Upgrade the extension's tasks to use NPM 16

### DIFF
--- a/tasks/JFrogAudit/task.json
+++ b/tasks/JFrogAudit/task.json
@@ -99,7 +99,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "audit.js",
             "workingDirectory": "$(currentDirectory)"
         }

--- a/tasks/JFrogBuildPromotion/task.json
+++ b/tasks/JFrogBuildPromotion/task.json
@@ -131,7 +131,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "buildPromotion.js",
             "argumentFormat": "",
             "workingDirectory": "$(currentDirectory)"

--- a/tasks/JFrogBuildScan/task.json
+++ b/tasks/JFrogBuildScan/task.json
@@ -69,7 +69,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "buildScan.js",
             "workingDirectory": "$(currentDirectory)"
         }

--- a/tasks/JFrogCliV2/task.json
+++ b/tasks/JFrogCliV2/task.json
@@ -66,7 +66,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "jfrogCliRun.js",
             "workingDirectory": "$(currentDirectory)"
         }

--- a/tasks/JFrogCollectIssues/task.json
+++ b/tasks/JFrogCollectIssues/task.json
@@ -93,7 +93,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "collectIssues.js",
             "workingDirectory": "$(currentDirectory)"
         }

--- a/tasks/JFrogConan/task.json
+++ b/tasks/JFrogConan/task.json
@@ -221,7 +221,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "conanBuild.js"
         }
     }

--- a/tasks/JFrogDiscardBuilds/task.json
+++ b/tasks/JFrogDiscardBuilds/task.json
@@ -85,7 +85,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "discardBuilds.js",
             "workingDirectory": "$(currentDirectory)"
         }

--- a/tasks/JFrogDistribution/task.json
+++ b/tasks/JFrogDistribution/task.json
@@ -276,7 +276,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "distribution.js",
             "workingDirectory": "$(currentDirectory)"
         }

--- a/tasks/JFrogDocker/task.json
+++ b/tasks/JFrogDocker/task.json
@@ -233,7 +233,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "docker.js",
             "workingDirectory": "$(currentDirectory)"
         }

--- a/tasks/JFrogDotnet/task.json
+++ b/tasks/JFrogDotnet/task.json
@@ -228,7 +228,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "dotnetBuild.js",
             "workingDirectory": "$(currentDirectory)"
         }

--- a/tasks/JFrogGenericArtifacts/task.json
+++ b/tasks/JFrogGenericArtifacts/task.json
@@ -393,7 +393,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "runGenericArtifacts.js"
         }
     }

--- a/tasks/JFrogGo/task.json
+++ b/tasks/JFrogGo/task.json
@@ -174,7 +174,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "goBuild.js"
         }
     }

--- a/tasks/JFrogGradle/task.json
+++ b/tasks/JFrogGradle/task.json
@@ -287,7 +287,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "gradleBuild.js",
             "workingDirectory": "$(currentDirectory)"
         }

--- a/tasks/JFrogMaven/task.json
+++ b/tasks/JFrogMaven/task.json
@@ -307,7 +307,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "mavenBuild.js",
             "workingDirectory": "$(currentDirectory)"
         }

--- a/tasks/JFrogNpm/task.json
+++ b/tasks/JFrogNpm/task.json
@@ -179,7 +179,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "npmBuild.js"
         }
     }

--- a/tasks/JFrogNuget/task.json
+++ b/tasks/JFrogNuget/task.json
@@ -215,7 +215,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "nugetBuild.js",
             "workingDirectory": "$(currentDirectory)"
         }

--- a/tasks/JFrogPip/task.json
+++ b/tasks/JFrogPip/task.json
@@ -152,7 +152,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "pipBuild.js",
             "workingDirectory": "$(currentDirectory)"
         }

--- a/tasks/JFrogPublishBuildInfo/task.json
+++ b/tasks/JFrogPublishBuildInfo/task.json
@@ -61,7 +61,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "publishBuildInfo.js",
             "workingDirectory": "$(currentDirectory)"
         }

--- a/tasks/JFrogToolsInstaller/task.json
+++ b/tasks/JFrogToolsInstaller/task.json
@@ -102,7 +102,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "toolsInstaller.js",
             "workingDirectory": "$(currentDirectory)"
         }

--- a/tests/resources/task.json
+++ b/tests/resources/task.json
@@ -3,7 +3,7 @@
     "name": "TaskJsonDummyForTests",
     "description": "Task json used to avoid the 'unable to find task json' warnings",
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "",
             "workingDirectory": "$(currentDirectory)"
         }


### PR DESCRIPTION
Upgrade the extension's tasks to use NPM 16
This aimes at resolving the following warning when tasks are executed.
```
##[warning]Task 'JFrog CLI V2' version 1 (JfrogCliV2@1) is dependent on a Node version (10) that is end-of-life. Contact the extension owner for an updated version of the task. Task maintainers should review Node upgrade guidance: https://aka.ms/node-runner-guidance
```