### PR TITLE
Fix Conan timestamp mismatch

### DIFF
--- a/tasks/JFrogConan/conanUtils.d.ts
+++ b/tasks/JFrogConan/conanUtils.d.ts
@@ -2,5 +2,6 @@
 // eslint-disable-next-line @typescript-eslint/no-namespace
 declare namespace conan_utils {
     function getCliPartialsBuildDir(buildName: string, buildNumber: string): string;
+    function initCliPartialsBuildDir(buildName: string, buildNumber: string): number;
 }
 export = conan_utils;

--- a/tasks/JFrogConan/conanUtils.js
+++ b/tasks/JFrogConan/conanUtils.js
@@ -28,7 +28,6 @@ function executeConanTask(commandArgs) {
 
         let conanTaskId = generateConanTaskUUId();
         tl.debug('Conan Task Id: ' + conanTaskId);
-        let buildTimestamp = Date.now();
 
         let conanPath = null;
         try {
@@ -58,7 +57,7 @@ function executeConanTask(commandArgs) {
             let buildName = tl.getInput('buildName', true);
             let buildNumber = tl.getInput('buildNumber', true);
             try {
-                initCliPartialsBuildDir(buildName, buildNumber);
+                let buildTimestamp = initCliPartialsBuildDir(buildName, buildNumber);
                 setConanTraceFileLocation(conanUserHome, conanTaskId);
                 setArtifactsBuildInfoProperties(conanUserHome, buildName, buildNumber, buildTimestamp);
             } catch (err) {
@@ -387,14 +386,56 @@ function purgeConanRemotes() {
  * Creates the path of for partials build info and initializing the details file with Timestamp.
  * @param buildName (string) - The build name
  * @param buildNumber (string) - The build number
+ * @returns {number} - The timestamp of the build in milliseconds.
  */
 function initCliPartialsBuildDir(buildName, buildNumber) {
     let partialsBuildDir = join(getCliPartialsBuildDir(buildName, buildNumber), 'partials');
+    let buildDetailsFile = join(partialsBuildDir, 'details');
+
+    // If a build was initialized before this task, read the build timestamp from the existing build details.
+    if (fs.pathExistsSync(buildDetailsFile)) {
+        let buildTimestamp = readTimestampFromPartial(buildDetailsFile);
+        if (buildTimestamp) {
+            tl.debug('Read timestamp "' + buildTimestamp + '" from partial build details at: ' + buildDetailsFile);
+            return buildTimestamp;
+        }
+    }
+    // If a build was not initialized, create a new build details file.
+    return createBuildDetailsPartial(partialsBuildDir, buildDetailsFile);
+}
+
+/**
+ * Creates the partial details file with the current timestamp.
+ * @param partialsBuildDir (string) - path to the build's partials directory.
+ * @param buildDetailsFile (string) - path to the build's partial build details file.
+ * @returns {number} - The timestamp of the build in milliseconds.
+ */
+function createBuildDetailsPartial(partialsBuildDir, buildDetailsFile) {
     if (!fs.pathExistsSync(partialsBuildDir)) {
         fs.ensureDirSync(partialsBuildDir);
     }
-    fs.writeJsonSync(join(partialsBuildDir, 'details'), { Timestamp: new Date().toISOString() });
-    tl.debug('Created partial details at: ' + join(partialsBuildDir, 'details'));
+
+    // The start time is saved as ISO, but the artifacts property is saved as a timestamp.
+    let buildStartTime = new Date();
+    fs.writeJsonSync(buildDetailsFile, { Timestamp: buildStartTime.toISOString() });
+    tl.debug('Created partial build details at: ' + buildDetailsFile);
+    return buildStartTime.getTime();
+}
+
+/**
+ * Reads the build start time from the build's partial build details file, and returns it as timestamp.
+ * @param buildDetailsFile (string) - path to the build's partial build details file.
+ * @returns {number} - The timestamp of the build in milliseconds.
+ */
+function readTimestampFromPartial(buildDetailsFile) {
+    try {
+        const data = fs.readFileSync(buildDetailsFile, 'utf8');
+        const jsonData = JSON.parse(data);
+        return Date.parse(jsonData.Timestamp);
+    } catch (err) {
+        console.error('Error reading or parsing the build details partials file:', err);
+        return undefined;
+    }
 }
 
 function getCliPartialsBuildDir(buildName, buildNumber) {
@@ -405,6 +446,8 @@ function getCliPartialsBuildDir(buildName, buildNumber) {
 
 module.exports = {
     executeConanTask: executeConanTask,
-    getCliPartialsBuildDir: getCliPartialsBuildDir, // Exported for tests
     purgeConanRemotes: purgeConanRemotes,
+    // Exported for tests:
+    getCliPartialsBuildDir: getCliPartialsBuildDir,
+    initCliPartialsBuildDir: initCliPartialsBuildDir,
 };

--- a/tasks/JFrogConan/conanUtils.js
+++ b/tasks/JFrogConan/conanUtils.js
@@ -390,18 +390,18 @@ function purgeConanRemotes() {
  */
 function initCliPartialsBuildDir(buildName, buildNumber) {
     let partialsBuildDir = join(getCliPartialsBuildDir(buildName, buildNumber), 'partials');
-    let buildDetailsFile = join(partialsBuildDir, 'details');
+    let partialBuildDetailsFile = join(partialsBuildDir, 'details');
 
     // If a build was initialized before this task, read the build timestamp from the existing build details.
-    if (fs.pathExistsSync(buildDetailsFile)) {
-        let buildTimestamp = readTimestampFromPartial(buildDetailsFile);
+    if (fs.pathExistsSync(partialBuildDetailsFile)) {
+        let buildTimestamp = readTimestampFromBuildPartialDetailsFile(partialBuildDetailsFile);
         if (buildTimestamp) {
-            tl.debug('Read timestamp "' + buildTimestamp + '" from partial build details at: ' + buildDetailsFile);
+            tl.debug('Read timestamp "' + buildTimestamp + '" from partial build details at: ' + partialBuildDetailsFile);
             return buildTimestamp;
         }
     }
     // If a build was not initialized, create a new build details file.
-    return createBuildDetailsPartial(partialsBuildDir, buildDetailsFile);
+    return createBuildDetailsPartial(partialsBuildDir, partialBuildDetailsFile);
 }
 
 /**
@@ -427,7 +427,7 @@ function createBuildDetailsPartial(partialsBuildDir, buildDetailsFile) {
  * @param buildDetailsFile (string) - path to the build's partial build details file.
  * @returns {number} - The timestamp of the build in milliseconds.
  */
-function readTimestampFromPartial(buildDetailsFile) {
+function readTimestampFromBuildPartialDetailsFile(buildDetailsFile) {
     try {
         const data = fs.readFileSync(buildDetailsFile, 'utf8');
         const jsonData = JSON.parse(data);

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -39,7 +39,7 @@ const repoKeys: any = {
     pipRemoteRepo: 'pip-remote',
     pipVirtualRepo: 'pip-virtual',
     releaseBundlesRepo: 'rb-repo',
-    dockerLocalRepo: 'docker-local'
+    dockerLocalRepo: 'docker-local',
 };
 
 export { testDataDir, repoKeys, platformUrl, platformPassword, platformUsername, platformAccessToken, platformDockerDomain };
@@ -165,7 +165,7 @@ export function createTestRepositories(): void {
             url: 'https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf',
         }),
     );
-    if (!isSkipTest('maven')) {    
+    if (!isSkipTest('maven')) {
         createRepo(repoKeys.mavenLocalRepo, JSON.stringify({ rclass: 'local', packageType: 'maven' }));
         createRepo(
             repoKeys.mavenRemoteRepo,
@@ -176,7 +176,7 @@ export function createTestRepositories(): void {
             }),
         );
     }
-    if (!isSkipTest('nuget') && !isSkipTest('dotnet')) {    
+    if (!isSkipTest('nuget') && !isSkipTest('dotnet')) {
         createRepo(
             repoKeys.nugetLocalRepo,
             JSON.stringify({
@@ -207,7 +207,7 @@ export function createTestRepositories(): void {
             }),
         );
     }
-    if (!isSkipTest('npm')) {    
+    if (!isSkipTest('npm')) {
         createRepo(
             repoKeys.npmLocalRepo,
             JSON.stringify({
@@ -235,10 +235,10 @@ export function createTestRepositories(): void {
             }),
         );
     }
-    if (!isSkipTest('conan')) {    
+    if (!isSkipTest('conan')) {
         createRepo(repoKeys.conanLocalRepo, JSON.stringify({ rclass: 'local', packageType: 'conan' }));
     }
-    if (!isSkipTest('go')) {    
+    if (!isSkipTest('go')) {
         createRepo(
             repoKeys.goLocalRepo,
             JSON.stringify({
@@ -266,7 +266,7 @@ export function createTestRepositories(): void {
             }),
         );
     }
-    if (!isSkipTest('pip')) {    
+    if (!isSkipTest('pip')) {
         createRepo(repoKeys.pipLocalRepo, JSON.stringify({ rclass: 'local', packageType: 'pypi', repoLayoutRef: 'simple-default' }));
         createRepo(
             repoKeys.pipRemoteRepo,
@@ -293,7 +293,7 @@ export function createTestRepositories(): void {
                 packageType: 'docker',
                 dockerApiVersion: 'V2',
                 dockerV1Enabled: false,
-                enableTokenAuthentication: true
+                enableTokenAuthentication: true,
             }),
         );
     }

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -219,6 +219,14 @@ describe('JFrog Artifactory Extension Tests', (): void => {
             },
             TestUtils.isSkipTest('unit'),
         );
+
+        runSyncTest(
+            'Conan Utils - Init build details partial and verify consistency in timestamp',
+            (): void => {
+                testInitCliPartialsBuildDir();
+            },
+            TestUtils.isSkipTest('unit'),
+        );
     });
 
     describe('JFrog CLI Task Tests', (): void => {
@@ -745,7 +753,9 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                 const filesDir: string = TestUtils.isWindows() ? 'windowsFiles' : 'unixFiles';
 
                 // Run docker build + tag
-                execSync(`docker build -t ${platformDockerDomain}/${repoKeys.dockerLocalRepo}/docker-test:1 ${join(__dirname, 'resources', testDir, filesDir)}`);
+                execSync(
+                    `docker build -t ${platformDockerDomain}/${repoKeys.dockerLocalRepo}/docker-test:1 ${join(__dirname, 'resources', testDir, filesDir)}`,
+                );
 
                 // run docker push
                 mockTask(testDir, 'push');
@@ -1225,6 +1235,31 @@ function testGetCliPartialsBuildDir(): void {
     testDTO.testsBuildNames.forEach((element: string): void => assertPathExists(conanUtils.getCliPartialsBuildDir(element, testDTO.testBuildNumber)));
     // Cleanup the created partials
     testDTO.testsBuildNames.forEach((element: string): void => runBuildCommand('bc', element, testDTO.testBuildNumber));
+}
+
+function testInitCliPartialsBuildDir(): void {
+    const testsBuildName: string = 'partialTestBuildName';
+    const testBuildNumber: string = '123';
+
+    // Cleanup old partials.
+    runBuildCommand('bc', testsBuildName, testBuildNumber);
+
+    // Init build partials directory. A new build timestamp should be generated.
+    let originalBuildTimestamp: number = conanUtils.initCliPartialsBuildDir(testsBuildName, testBuildNumber);
+    assert.ok(originalBuildTimestamp, 'A timestamp should have been generated');
+    assert.equal(originalBuildTimestamp.toString().length, 13, 'The timestamp should be valid');
+
+    // Calling initialization again. Since it already exists, we expect the same timestamp to be returned.
+    let newBuildTimestamp: number = conanUtils.initCliPartialsBuildDir(testsBuildName, testBuildNumber);
+    assert.equal(originalBuildTimestamp, newBuildTimestamp, 'The timestamp should not have changed');
+
+    // Cleanup existing partials, init again and assert the new timestamp.
+    runBuildCommand('bc', testsBuildName, testBuildNumber);
+    newBuildTimestamp = conanUtils.initCliPartialsBuildDir(testsBuildName, testBuildNumber);
+    assert.notEqual(originalBuildTimestamp, newBuildTimestamp, 'The timestamp should have changed');
+
+    // Cleanup test.
+    runBuildCommand('bc', testsBuildName, testBuildNumber);
 }
 
 function runBuildCommand(command: string, buildName: string, buildNumber: string): void {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Following #528 

This PR introduces changes that will improve consistency of the build timestamp for Conan build and their artifacts.

So far a timestamp was generated for every new Conan task, and again when setting the artifact build timestamp property.
The mismatch in timestamp between a build and its artifacts was causing issue when trying to delete the artifacts by their build.
From now on, the timestamp will only be generated once per build.

Tests will pass after merging https://github.com/jfrog/jfrog-azure-devops-extension/pull/530