### PR TITLE
OIDC token exchange fix with cli version upgrade

### DIFF
--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -10,7 +10,7 @@ const semver = require('semver');
 const fileName = getCliExecutableName();
 const jfrogCliToolName = 'jf';
 const cliPackage = 'jfrog-cli-' + getArchitecture();
-const defaultJfrogCliVersion = '2.81.0';
+const defaultJfrogCliVersion = '2.85.0';
 
 /**
  * Safely constructs the JFrog tools directory path, handling potential issues with Agent.ToolsDirectory
@@ -32,7 +32,7 @@ const minCustomCliVersion = '2.10.0';
 const minSupportedStdinSecretCliVersion = '2.36.0';
 const minSupportedServerIdEnvCliVersion = '2.37.0';
 const minSupportedOidcCliVersion = '2.75.0';
-const pluginVersion = '2.12.2';
+const pluginVersion = '2.13.0';
 const buildAgent = 'jfrog-azure-devops-extension';
 
 /**
@@ -436,7 +436,15 @@ function configureSpecificCliServer(service, urlFlag, serverId, cliPath, buildDi
     // This is done by the exchange command and not the config to export
     // username and access token params for further use by the users.
     if (oidcProviderName) {
-        serviceAccessToken = exchangeOidcTokenAndSetStepVariables(service, serviceUrl, oidcProviderName, cliPath, buildDir);
+        // we need artifactory url for oidc token exchange
+        let artifactoryUrl = serviceUrl;
+        if (serviceUrl.endsWith('/xray')) {
+            artifactoryUrl = serviceUrl.replace('/xray', '');
+        }
+        if (serviceUrl.endsWith('/artifactory')) {
+            artifactoryUrl = serviceUrl.replace('/artifactory', '');
+        }
+        serviceAccessToken = exchangeOidcTokenAndSetStepVariables(service, artifactoryUrl, oidcProviderName, cliPath, buildDir);
     }
 
     if (serviceAccessToken) {

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -436,15 +436,15 @@ function configureSpecificCliServer(service, urlFlag, serverId, cliPath, buildDi
     // This is done by the exchange command and not the config to export
     // username and access token params for further use by the users.
     if (oidcProviderName) {
-        // we need artifactory url for oidc token exchange
-        let artifactoryUrl = serviceUrl;
+        // we need platform url for oidc token exchange
+        let platformUrl = serviceUrl;
         if (serviceUrl.endsWith('/xray')) {
-            artifactoryUrl = serviceUrl.replace('/xray', '');
+            platformUrl = serviceUrl.replace('/xray', '');
         }
         if (serviceUrl.endsWith('/artifactory')) {
-            artifactoryUrl = serviceUrl.replace('/artifactory', '');
+            platformUrl = serviceUrl.replace('/artifactory', '');
         }
-        serviceAccessToken = exchangeOidcTokenAndSetStepVariables(service, artifactoryUrl, oidcProviderName, cliPath, buildDir);
+        serviceAccessToken = exchangeOidcTokenAndSetStepVariables(service, platformUrl, oidcProviderName, cliPath, buildDir);
     }
 
     if (serviceAccessToken) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Problem statement:
fix oidc token exchange for jf audit command

reason: for token exchange jf eot command is used which requires platform url and since xray connection was provided, xray url was used, this caused command failure.