### PR TITLE
Save Audit logs to azure artifacts

### DIFF
--- a/tasks/JFrogAudit/audit.ts
+++ b/tasks/JFrogAudit/audit.ts
@@ -1,8 +1,37 @@
 import * as utils from '@jfrog/tasks-utils';
 import * as tl from 'azure-pipelines-task-lib/task';
+import * as path from 'path';
+import * as os from 'os';
 
 const cliAuditCommand: string = 'audit';
 let serverId: string;
+
+/**
+ * Publishes JFrog logs as a pipeline artifact for debugging purposes.
+ * Useful for accessing JAS scanner logs (analyzerManagerLogs, etc.)
+ */
+function publishJFrogLogs(): void {
+    try {
+        const publishLogs: boolean = tl.getBoolInput('publishLogs', false);
+        if (!publishLogs) {
+            return;
+        }
+        const jfrogHome: string = process.env.JFROG_CLI_HOME_DIR || path.join(os.homedir(), '.jfrog');
+        const logsPath: string = path.join(jfrogHome, 'logs');
+        if (tl.exist(logsPath)) {
+            // Create unique artifact name using BuildId and JobAttempt
+            const buildId: string = tl.getVariable('Build.BuildId') || 'unknown';
+            const jobAttempt: string = tl.getVariable('System.JobAttempt') || '1';
+            const artifactName: string = `jfrog-audit-logs-${buildId}-${jobAttempt}`;
+            tl.debug(`Publishing JFrog logs from: ${logsPath}`);
+            tl.command('artifact.upload', { containerfolder: 'jfrog-audit-logs', artifactname: artifactName }, logsPath);
+        } else {
+            tl.warning(`JFrog logs directory not found at: ${logsPath}`);
+        }
+    } catch (err) {
+        tl.warning(`Failed to publish JFrog logs: ${err}`);
+    }
+}
 
 function RunTaskCbk(cliPath: string): void {
     const inputWorkingDirectory: string = tl.getInput('workingDirectory', false) ?? '';
@@ -41,6 +70,7 @@ function executeCliCommand(cliCmd: string, buildDir: string, cliPath: string): v
     } catch (ex) {
         tl.setResult(tl.TaskResult.Failed, ex as string);
     } finally {
+        publishJFrogLogs();
         utils.taskDefaultCleanup(cliPath, buildDir, [serverId]);
     }
 }

--- a/tasks/JFrogAudit/task.json
+++ b/tasks/JFrogAudit/task.json
@@ -96,6 +96,14 @@
             "required": true,
             "visibleRule": "watchesSource!=none",
             "helpMarkDown": "Unset if you don't wish the audit process to exit with code 3, if a violation matching an Xray policy is found, and the policy includes a 'Fail Build' rule."
+        },
+        {
+            "name": "publishLogs",
+            "type": "boolean",
+            "label": "Publish execution logs to azure artifact",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "When enabled, publishes .jfrog/logs directory as a pipeline artifact for debugging. Includes JAS scanner logs (analyzerManagerLogs)."
         }
     ],
     "execution": {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----


Description:
After the audit command failure there was no way to retrieve analyzerManager logs, this PR aims to push the respective logs azure artifacts