### PR TITLE
Use latest cli version by default

### DIFF
--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -10,7 +10,117 @@ const semver = require('semver');
 const fileName = getCliExecutableName();
 const jfrogCliToolName = 'jf';
 const cliPackage = 'jfrog-cli-' + getArchitecture();
-const defaultJfrogCliVersion = '2.85.0';
+const fallbackCliVersion = '2.89.0';
+let defaultJfrogCliVersion = null;
+
+/**
+ * Executes an HTTP request with retry logic for 5xx errors.
+ * @param {string} method - HTTP method (GET, POST, etc.)
+ * @param {string} url - Request URL
+ * @param {object} options - Request options (timeout, headers, etc.)
+ * @param {number} maxRetries - Maximum number of retry attempts (default: 3)
+ * @param {number} retryDelay - Delay between retries in ms (default: 1000)
+ * @returns {object} Response object from syncRequest on success
+ * @throws {Error} If all retries fail (network errors or 5xx responses)
+ */
+function syncRequestWithRetry(method, url, options = {}, maxRetries = 3, retryDelay = 1000) {
+    let errorToThrow = null;
+    let lastResponse = null;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+            const response = syncRequest(method, url, options);
+            // Retry on 5xx server errors
+            if (response?.statusCode >= 500 && response?.statusCode < 600) {
+                console.warn(`Attempt ${attempt}/${maxRetries}: Server error ${response?.statusCode} for ${url}`);
+                lastResponse = response;
+            } else {
+                return response;
+            }
+        } catch (err) {
+            console.warn(`Attempt ${attempt}/${maxRetries}: Request failed for ${url} - ${err?.message}`);
+            errorToThrow = err;
+        }
+
+        if (attempt < maxRetries) {
+            // Blocking delay before retry
+            const waitUntil = Date.now() + retryDelay;
+            while (Date.now() < waitUntil) { /* wait */ }
+        }
+    }
+
+    // All retries exhausted - throw error for both network failures and 5xx responses
+    if (errorToThrow) {
+        throw errorToThrow;
+    }
+    if (lastResponse) {
+        throw new Error(`Server error ${lastResponse.statusCode} after ${maxRetries} retries for ${url}`);
+    }
+}
+
+/**
+ * Checks if the CLI binary exists on releases.jfrog.io for the given version.
+ * @param {string} version - The CLI version to check
+ * @returns {boolean} True if binary exists, false otherwise
+ */
+function isCliBinaryAvailable(version) {
+    const binaryUrl = `https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/${version}/${cliPackage}/${fileName}`;
+    try {
+        console.log('Verifying CLI binary availability at: ' + binaryUrl);
+        const res = syncRequestWithRetry('HEAD', binaryUrl, { timeout: 5000 });
+        return res?.statusCode === 200;
+    } catch (err) {
+        console.warn('Failed to verify CLI binary availability: ' + err?.message);
+        return false;
+    }
+}
+
+/**
+ * Fetches the latest available JFrog CLI version from GitHub releases with retry mechanism.
+ * Validates that the binary is available on releases.jfrog.io before returning.
+ * If the latest release binary isn't available, falls back to the previous release.
+ * Called once during module initialization. Result is cached in defaultJfrogCliVersion.
+ * @returns {string} The CLI version (e.g., '2.89.0') or fallback if fetch fails or no binary available
+ */
+function fetchLatestCliVersion() {
+    try {
+        console.log('Fetching JFrog CLI releases from https://api.github.com/repos/jfrog/jfrog-cli/releases');
+        const res = syncRequestWithRetry('GET', 'https://api.github.com/repos/jfrog/jfrog-cli/releases?per_page=3', {
+            headers: { 'User-Agent': 'jfrog-azure-devops-extension' },
+            timeout: 5000,
+        });
+        if (res.statusCode === 200) {
+            const releases = JSON.parse(res.getBody('utf8'));
+            console.log('Fetched ' + releases?.length ?? 0 + ' JFrog CLI releases');
+
+            if (!releases || releases.length === 0) {
+                console.warn('No JFrog CLI releases found, using fallback: ' + fallbackCliVersion);
+                return fallbackCliVersion;
+            }
+
+            // Try each release until we find one with an available binary
+            for (const release of releases) {
+                const version = release?.name;
+                console.log('Checking CLI version: ' + version);
+
+                if (version && isCliBinaryAvailable(version)) {
+                    console.log('CLI binary verified available for version: ' + version);
+                    return version;
+                }
+                console.warn('CLI binary not yet available for version: ' + version);
+            }
+            console.warn('No CLI binaries available for last 3 releases, using fallback: ' + fallbackCliVersion);
+            return fallbackCliVersion;
+        }
+        console.warn('Unexpected status code: ' + res.statusCode + ', using fallback version: ' + fallbackCliVersion);
+    } catch (err) {
+        console.warn('Failed to fetch JFrog CLI releases, due to error: ' + err?.message + ', using fallback: ' + fallbackCliVersion);
+    }
+    return fallbackCliVersion;
+}
+
+// Fetch and cache the CLI version during module initialization
+defaultJfrogCliVersion = fetchLatestCliVersion();
 
 /**
  * Safely constructs the JFrog tools directory path, handling potential issues with Agent.ToolsDirectory
@@ -69,6 +179,9 @@ const jfrogCliConfigUseCommand = 'c use';
 let runTaskCbk = null;
 
 module.exports = {
+    syncRequestWithRetry: syncRequestWithRetry,
+    isCliBinaryAvailable: isCliBinaryAvailable,
+    fetchLatestCliVersion: fetchLatestCliVersion,
     executeCliTask: executeCliTask,
     executeCliCommand: executeCliCommand,
     downloadCli: downloadCli,
@@ -112,6 +225,7 @@ module.exports = {
     configureDefaultXrayServer: configureDefaultXrayServer,
     minCustomCliVersion: minCustomCliVersion,
     defaultJfrogCliVersion: defaultJfrogCliVersion,
+    fallbackCliVersion: fallbackCliVersion,
     pipelineRequestedCliVersionEnv: pipelineRequestedCliVersionEnv,
     taskSelectedCliVersionEnv: taskSelectedCliVersionEnv,
     extractorsRemoteEnv: extractorsRemoteEnv,

--- a/tasks/JFrogConan/conanUtils.js
+++ b/tasks/JFrogConan/conanUtils.js
@@ -1,7 +1,8 @@
 const tl = require('azure-pipelines-task-lib/task');
 const { v4: uuid } = require('uuid');
-const tmpdir = require('os').tmpdir;
-const EOL = require('os').EOL;
+const os = require('os');
+const tmpdir = os.tmpdir;
+const EOL = os.EOL;
 const fs = require('fs-extra');
 const join = require('path').join;
 const createHash = require('crypto').createHash;
@@ -14,7 +15,23 @@ const BUILD_INFO_BUILD_NAME = 'name';
 const BUILD_INFO_BUILD_NUMBER = 'number';
 const BUILD_INFO_BUILD_STARTED = 'started';
 const BUILD_INFO_FILE_NAME = 'generatedBuildInfo';
-const BUILD_TEMP_PATH = 'jfrog/builds';
+
+/**
+ * Get the JFrog CLI build temp directory path segments.
+ * On Windows: jfrog-<COMPUTERNAME>/<USERNAME>
+ * On macOS/Linux: jfrog-<USERNAME>
+ * @returns {string[]} Array of path segments to join
+ */
+function getJfrogBuildDirSegments() {
+    const username = os.userInfo().username;
+    if (process.platform === 'win32') {
+        // On Windows, the CLI uses: jfrog-<COMPUTERNAME>/<USERNAME>/builds
+        const hostname = os.hostname();
+        return [`jfrog-${hostname}`, username];
+    }
+    // On macOS/Linux: jfrog-<USERNAME>/builds
+    return [`jfrog-${username}`];
+}
 
 /**
  * Execute Artifactory Conan Task
@@ -441,7 +458,10 @@ function readTimestampFromBuildPartialDetailsFile(buildDetailsFile) {
 function getCliPartialsBuildDir(buildName, buildNumber) {
     const buildId = buildName + '_' + buildNumber + '_' + '';
     const hexId = createHash('sha256').update(buildId).digest('hex');
-    return join(tmpdir(), BUILD_TEMP_PATH, hexId);
+    // Use separate path segments to ensure correct path separators on all platforms
+    // On Windows: <tmpdir>/jfrog-<COMPUTERNAME>/<USERNAME>/builds/<hash>
+    // On macOS/Linux: <tmpdir>/jfrog-<USERNAME>/builds/<hash>
+    return join(tmpdir(), ...getJfrogBuildDirSegments(), 'builds', hexId);
 }
 
 module.exports = {

--- a/tests/resources/conanTask/files/conan-min/conanfile.py
+++ b/tests/resources/conanTask/files/conan-min/conanfile.py
@@ -14,7 +14,8 @@ class ConanminConan(ConanFile):
     exports_sources = "src/*"
 
     def requirements(self):
-        self.requires("boost/[>=1.77]")
+        # Using fmt - a header-only library that avoids CMake compatibility issues
+        self.requires("fmt/[>=8.0.1]")
 
     def build(self):
         cmake = CMake(self)

--- a/tests/resources/maven/resources/pom.xml
+++ b/tests/resources/maven/resources/pom.xml
@@ -44,6 +44,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -2,7 +2,7 @@ import * as mockRun from 'azure-pipelines-task-lib/mock-run';
 import * as tl from 'azure-pipelines-task-lib/task';
 import { join, basename } from 'path';
 import * as fs from 'fs-extra';
-import rimraf from 'rimraf';
+import { rimrafSync } from 'rimraf';
 import * as syncRequest from 'sync-request';
 import * as assert from 'assert';
 import NullWritable from 'null-writable';
@@ -114,7 +114,7 @@ export function runTaskForService(testMain: string, variables: any, inputs: any)
 
 export function recreateTestDataDir(): void {
     if (fs.existsSync(testDataDir)) {
-        rimraf.sync(testDataDir);
+        rimrafSync(testDataDir);
     }
     fs.mkdirSync(testDataDir);
 }
@@ -145,7 +145,7 @@ export function cleanToolCache(): void {
 export function cleanUpAllTests(): void {
     if (fs.existsSync(testDataDir)) {
         try {
-            rimraf.sync(testDataDir);
+            rimrafSync(testDataDir);
         } catch (err) {
             console.warn('Tests cleanup issue: ' + err);
         }

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -54,7 +54,7 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                             repoKeys.repo1 +
                             '/' +
                             ' --url=' +
-                            jfrogUtils.quote(process.env.ADO_JFROG_PLATFORM_URL + 'artifactory') +
+                            jfrogUtils.quote(process.env.ADO_JFROG_PLATFORM_URL ?? '') +
                             ' --user=' +
                             jfrogUtils.quote(process.env.ADO_JFROG_PLATFORM_USERNAME ?? '') +
                             ' --password=' +
@@ -1279,6 +1279,18 @@ function testInitCliPartialsBuildDir(): void {
     runBuildCommand('bc', testsBuildName, testBuildNumber);
 }
 
+function getJfrogCliPath(): string {
+    const versions: string[] = toolLib.findLocalToolVersions('jf');
+    if (versions.length === 0) {
+        // Fallback to PATH-based execution if CLI is not in tool cache
+        return 'jf';
+    }
+    const cliDir: string = toolLib.findLocalTool('jf', versions[0]);
+    const executableName: string = process.platform.startsWith('win') ? 'jf.exe' : 'jf';
+    return join(cliDir, executableName);
+}
+
 function runBuildCommand(command: string, buildName: string, buildNumber: string): void {
-    jfrogUtils.executeCliCommand('jf rt ' + command + ' "' + buildName + '" ' + buildNumber, TestUtils.testDataDir);
+    const cliPath: string = getJfrogCliPath();
+    jfrogUtils.executeCliCommand(cliPath + ' rt ' + command + ' "' + buildName + '" ' + buildNumber, TestUtils.testDataDir);
 }

--- a/tests/utilsTests.ts
+++ b/tests/utilsTests.ts
@@ -152,12 +152,12 @@ describe('Utils Unit Tests', (): void => {
 
     describe('syncRequestWithRetry', (): void => {
         it('should return response on successful request (2xx)', (): void => {
-            const response = jfrogUtils.syncRequestWithRetry('GET', 'https://httpstat.us/200', { timeout: 5000 });
+            const response: { statusCode: number } = jfrogUtils.syncRequestWithRetry('GET', 'https://httpstat.us/200', { timeout: 5000 });
             assert.strictEqual(response.statusCode, 200);
         });
 
         it('should return response on 4xx client error without retry', (): void => {
-            const response = jfrogUtils.syncRequestWithRetry('GET', 'https://httpstat.us/404', { timeout: 5000 });
+            const response: { statusCode: number } = jfrogUtils.syncRequestWithRetry('GET', 'https://httpstat.us/404', { timeout: 5000 });
             assert.strictEqual(response.statusCode, 404);
         });
 
@@ -183,31 +183,31 @@ describe('Utils Unit Tests', (): void => {
     describe('isCliBinaryAvailable', (): void => {
         it('should return true for a known valid CLI version', (): void => {
             // Use a known stable version that should always be available
-            const result = jfrogUtils.isCliBinaryAvailable('2.50.0');
+            const result: boolean = jfrogUtils.isCliBinaryAvailable('2.50.0');
             assert.strictEqual(result, true);
         });
 
         it('should return false for a non-existent CLI version', (): void => {
-            const result = jfrogUtils.isCliBinaryAvailable('0.0.1');
+            const result: boolean = jfrogUtils.isCliBinaryAvailable('0.0.1');
             assert.strictEqual(result, false);
         });
 
         it('should return false for an invalid version format', (): void => {
-            const result = jfrogUtils.isCliBinaryAvailable('invalid-version');
+            const result: boolean = jfrogUtils.isCliBinaryAvailable('invalid-version');
             assert.strictEqual(result, false);
         });
     });
 
     describe('fetchLatestCliVersion', (): void => {
         it('should return a valid semver version string', (): void => {
-            const version = jfrogUtils.fetchLatestCliVersion();
+            const version: string = jfrogUtils.fetchLatestCliVersion();
             // Version should match semver pattern (e.g., "2.89.0")
             assert.match(version, /^\d+\.\d+\.\d+$/);
         });
 
         it('should return version >= 2.50.0 (reasonable minimum)', (): void => {
-            const version = jfrogUtils.fetchLatestCliVersion();
-            const [major, minor] = version.split('.').map(Number);
+            const version: string = jfrogUtils.fetchLatestCliVersion();
+            const [major, minor]: number[] = version.split('.').map(Number);
             assert.ok(major >= 2, `Major version ${major} should be >= 2`);
             if (major === 2) {
                 assert.ok(minor >= 50, `Minor version ${minor} should be >= 50 for major version 2`);
@@ -224,7 +224,7 @@ describe('Utils Unit Tests', (): void => {
         it('should match the result of fetchLatestCliVersion', (): void => {
             // Since defaultJfrogCliVersion is set at module load, it should match fetchLatestCliVersion
             // unless there was a failure (in which case both would use fallback)
-            const fetchedVersion = jfrogUtils.fetchLatestCliVersion();
+            const fetchedVersion: string = jfrogUtils.fetchLatestCliVersion();
             assert.strictEqual(jfrogUtils.defaultJfrogCliVersion, fetchedVersion);
         });
     });
@@ -237,7 +237,7 @@ describe('Utils Unit Tests', (): void => {
 
         it('should have an available binary on releases.jfrog.io', (): void => {
             // The fallback version should always have its binary available
-            const result = jfrogUtils.isCliBinaryAvailable(jfrogUtils.fallbackCliVersion);
+            const result: boolean = jfrogUtils.isCliBinaryAvailable(jfrogUtils.fallbackCliVersion);
             assert.strictEqual(result, true, `Fallback version ${jfrogUtils.fallbackCliVersion} should have available binary`);
         });
     });

--- a/tests/utilsTests.ts
+++ b/tests/utilsTests.ts
@@ -4,6 +4,21 @@ import * as assert from 'assert';
 // Use require to get the actual module with latest exports
 import * as jfrogUtils from '@jfrog/tasks-utils';
 
+// Type declarations for the new exported functions
+declare module '@jfrog/tasks-utils' {
+    export function syncRequestWithRetry(
+        method: string,
+        url: string,
+        options?: object,
+        maxRetries?: number,
+        retryDelay?: number,
+    ): { statusCode: number; getBody(encoding: string): string };
+    export function isCliBinaryAvailable(version: string): boolean;
+    export function fetchLatestCliVersion(): string;
+    export const defaultJfrogCliVersion: string;
+    export const fallbackCliVersion: string;
+}
+
 /**
  * Simulates the platformUrl resolution logic from utils.js lines 441-449:
  *
@@ -132,6 +147,98 @@ describe('Utils Unit Tests', (): void => {
                 jfrogUtils.parsePlatformUrlFromServiceUrl('https://artifactory.com/jfrog/artifactory'),
                 'https://artifactory.com/jfrog',
             );
+        });
+    });
+
+    describe('syncRequestWithRetry', (): void => {
+        it('should return response on successful request (2xx)', (): void => {
+            const response = jfrogUtils.syncRequestWithRetry('GET', 'https://httpstat.us/200', { timeout: 5000 });
+            assert.strictEqual(response.statusCode, 200);
+        });
+
+        it('should return response on 4xx client error without retry', (): void => {
+            const response = jfrogUtils.syncRequestWithRetry('GET', 'https://httpstat.us/404', { timeout: 5000 });
+            assert.strictEqual(response.statusCode, 404);
+        });
+
+        it('should throw error after retries exhausted on 5xx server error', (): void => {
+            assert.throws(
+                (): void => {
+                    jfrogUtils.syncRequestWithRetry('GET', 'https://httpstat.us/503', { timeout: 5000 }, 2, 100);
+                },
+                /Server error 503 after 2 retries/,
+            );
+        });
+
+        it('should throw error on network failure after retries', (): void => {
+            assert.throws(
+                (): void => {
+                    jfrogUtils.syncRequestWithRetry('GET', 'https://invalid.domain.that.does.not.exist.example', { timeout: 1000 }, 2, 100);
+                },
+                Error,
+            );
+        });
+    });
+
+    describe('isCliBinaryAvailable', (): void => {
+        it('should return true for a known valid CLI version', (): void => {
+            // Use a known stable version that should always be available
+            const result = jfrogUtils.isCliBinaryAvailable('2.50.0');
+            assert.strictEqual(result, true);
+        });
+
+        it('should return false for a non-existent CLI version', (): void => {
+            const result = jfrogUtils.isCliBinaryAvailable('0.0.1');
+            assert.strictEqual(result, false);
+        });
+
+        it('should return false for an invalid version format', (): void => {
+            const result = jfrogUtils.isCliBinaryAvailable('invalid-version');
+            assert.strictEqual(result, false);
+        });
+    });
+
+    describe('fetchLatestCliVersion', (): void => {
+        it('should return a valid semver version string', (): void => {
+            const version = jfrogUtils.fetchLatestCliVersion();
+            // Version should match semver pattern (e.g., "2.89.0")
+            assert.match(version, /^\d+\.\d+\.\d+$/);
+        });
+
+        it('should return version >= 2.50.0 (reasonable minimum)', (): void => {
+            const version = jfrogUtils.fetchLatestCliVersion();
+            const [major, minor] = version.split('.').map(Number);
+            assert.ok(major >= 2, `Major version ${major} should be >= 2`);
+            if (major === 2) {
+                assert.ok(minor >= 50, `Minor version ${minor} should be >= 50 for major version 2`);
+            }
+        });
+    });
+
+    describe('defaultJfrogCliVersion', (): void => {
+        it('should be initialized with a valid version', (): void => {
+            assert.ok(jfrogUtils.defaultJfrogCliVersion, 'defaultJfrogCliVersion should be defined');
+            assert.match(jfrogUtils.defaultJfrogCliVersion, /^\d+\.\d+\.\d+$/);
+        });
+
+        it('should match the result of fetchLatestCliVersion', (): void => {
+            // Since defaultJfrogCliVersion is set at module load, it should match fetchLatestCliVersion
+            // unless there was a failure (in which case both would use fallback)
+            const fetchedVersion = jfrogUtils.fetchLatestCliVersion();
+            assert.strictEqual(jfrogUtils.defaultJfrogCliVersion, fetchedVersion);
+        });
+    });
+
+    describe('fallbackCliVersion', (): void => {
+        it('should be a valid semver version string', (): void => {
+            assert.ok(jfrogUtils.fallbackCliVersion, 'fallbackCliVersion should be defined');
+            assert.match(jfrogUtils.fallbackCliVersion, /^\d+\.\d+\.\d+$/);
+        });
+
+        it('should have an available binary on releases.jfrog.io', (): void => {
+            // The fallback version should always have its binary available
+            const result = jfrogUtils.isCliBinaryAvailable(jfrogUtils.fallbackCliVersion);
+            assert.strictEqual(result, true, `Fallback version ${jfrogUtils.fallbackCliVersion} should have available binary`);
         });
     });
 });


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
Description:
This PR aims to solve the issue for updating jfrog-cli version after every release manually.

Solution:
Now we'll check for latest cli release from github api and use that as the default cli version.