### PR TITLE
RTECO-796 Fix allowFailBuild parameter

### DIFF
--- a/tasks/JFrogDocker/docker.ts
+++ b/tasks/JFrogDocker/docker.ts
@@ -28,9 +28,7 @@ function RunTaskCbk(cliPath: string): void {
         }
         case 'Scan': {
             serverId = utils.configureDefaultXrayServer('xray_docker_scan', cliPath, defaultWorkDir);
-            if (tl.getBoolInput('allowFailBuild', false)) {
-                cliCommand = utils.addBoolParam(cliCommand, 'allowFailBuild', 'fail');
-            }
+            cliCommand = utils.addBoolParam(cliCommand, 'allowFailBuild', 'fail');
 
             if (tl.getBoolInput('allowBypassArchiveLimits', false)) {
                 cliCommand = utils.addBoolParam(cliCommand, 'allowBypassArchiveLimits', 'bypass-archive-limits');


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
# Fix: allowFailBuild parameter ignored in JFrogDocker Scan

## Problem
When `allowFailBuild: false` is set, pipelines still fail on Xray violations with exit code 3.

## Root Cause
`docker.ts` line 31 wrapped `addBoolParam()` in a conditional check:
```typescript
if (tl.getBoolInput('allowFailBuild', false)) {
    cliCommand = utils.addBoolParam(cliCommand, 'allowFailBuild', 'fail');
}
```
When `allowFailBuild: false`, no `--fail` flag was passed to CLI, causing it to default to failing the build.

## Fix
```typescript
cliCommand = utils.addBoolParam(cliCommand, 'allowFailBuild', 'fail');
```
Now always passes `--fail=true` or `--fail=false` to CLI based on the parameter value.

## Files Changed
- `tasks/JFrogDocker/docker.ts` (1 line)
