### PR TITLE
RTECO-524 - Add proxy support for OIDC authentication

### DIFF
--- a/jfrog-tasks-utils/utils.d.ts
+++ b/jfrog-tasks-utils/utils.d.ts
@@ -45,6 +45,7 @@ declare module '@jfrog/tasks-utils' {
         repoResolver: string,
         repoDeploy: string,
     ): string[];
+    export function forwardProxyToEnv(): void;
     export function getProxyConfiguration(): object;
     export function setJdkHomeForJavaTasks(): void;
     export function fetchAzureOidcToken(serviceConnectionID: string): Promise<string>;

--- a/jfrog-tasks-utils/utils.d.ts
+++ b/jfrog-tasks-utils/utils.d.ts
@@ -3,7 +3,7 @@ import * as ifm from 'typed-rest-client/Interfaces';
 
 declare module '@jfrog/tasks-utils' {
     export function executeCliTask(
-        runTaskFunc: (cliPath: string) => void,
+        runTaskFunc: (cliPath: string) => void | Promise<void>,
         cliVersion?: string,
         cliDownloadUrl?: string,
         cliAuthHandlers?: ifm.IRequestHandler[],
@@ -24,6 +24,19 @@ declare module '@jfrog/tasks-utils' {
     export function addBoolParam(cliCommand: string, inputParam: string, cliParam: string): string;
     export function addStringParam(cliCommand: string, inputParam: string, cliParam: string, require: boolean): string;
     export function addIntParam(cliCommand: string, inputParam: string, cliParam: string): string;
+    export function addProjectOption(cliCommand: string): string;
+    export function addServerIdOption(cliCommand: string, serverId: string): string;
+    export function assembleUniqueServerId(usageType: string): string;
+    export function taskDefaultCleanup(cliPath: string, workDir: string, serverIdsArray: string[]): string;
+    export function appendBuildFlagsToCliCommand(cliCommand: string): string;
+    export function isToolExists(tool: string): boolean;
+    export function removeExtractorsDownloadVariables(cliPath: string, workDir: string): void;
+    export function configureArtifactoryCliServer(artifactoryService: string, serverId: string, cliPath: string, buildDir: string): void;
+    export function configureJfrogCliServer(jfrogService: string, serverId: string, cliPath: string, buildDir: string): Promise<void>;
+    export function configureDefaultJfrogServer(serverId: string, cliPath: string, workDir: string): Promise<boolean>;
+    export function configureDefaultArtifactoryServer(usageType: string, cliPath: string, workDir: string): string;
+    export function configureDefaultDistributionServer(usageType: string, cliPath: string, workDir: string): string;
+    export function configureDefaultXrayServer(usageType: string, cliPath: string, workDir: string): string;
     export function createBuildToolConfigFile(
         cliPath: string,
         cmd: string,
@@ -32,26 +45,34 @@ declare module '@jfrog/tasks-utils' {
         repoResolver: string,
         repoDeploy: string,
     ): string[];
-    export function addProjectOption(cliCommand: string): string;
-    export function addServerIdOption(cliCommand: string, serverId: string): string;
-    export function assembleUniqueServerId(usageType: string): string;
-    export function configureDefaultXrayServer(usageType: string, cliPath: string, workDir: string): string;
-    export function configureDefaultArtifactoryServer(usageType: string, cliPath: string, workDir: string): string;
-    export function configureDefaultDistributionServer(usageType: string, cliPath: string, workDir: string): string;
-    export function taskDefaultCleanup(cliPath: string, workDir: string, serverIdsArray: string[]): string;
-    export function appendBuildFlagsToCliCommand(cliCommand: string): string;
-    export function isToolExists(tool: string): boolean;
-    export function removeExtractorsDownloadVariables(cliPath: string, workDir: string);
-    export function configureArtifactoryCliServer(artifactoryService: string, serverId: string, cliPath: string, buildDir: string);
-    export function setJdkHomeForJavaTasks();
-    export function fetchAzureOidcToken(serviceConnectionID: string): string;
+    export function getProxyConfiguration(): object;
+    export function setJdkHomeForJavaTasks(): void;
+    export function fetchAzureOidcToken(serviceConnectionID: string): Promise<string>;
     export function exchangeOidcTokenAndSetStepVariables(
-        service: service,
+        service: string,
         serviceUrl: string,
         oidcProviderName: string,
         cliPath: string,
         buildDir: string,
-    ): string;
+    ): Promise<string>;
     export function parsePlatformUrlFromServiceUrl(serviceUrl: string): string;
-    export { taskSelectedCliVersionEnv };
+    export function addTrailingSlashIfNeeded(str: string): string;
+    export function buildCliArtifactoryDownloadUrl(rtUrl: string, repoName: string, cliVersion?: string): string;
+    export function createAuthHandlers(serviceConnection: string): ifm.IRequestHandler[];
+    export function stripTrailingSlash(str: string): string;
+    export function writeSpecContentToSpecPath(specSource: string, specPath: string): void;
+    export function addCommonGenericParams(cliCommand: string, specPath: string): string;
+    export function isServerIdEnvSupported(): boolean;
+    export function useCliServer(serverId: string, cliPath: string, buildDir: string): void;
+    export function getCurrentTimestamp(): number;
+    export function isWindows(): boolean;
+    export function singleQuote(str: string): string;
+    export function syncRequestWithRetry(method: string, url: string, options?: object, maxRetries?: number, retryDelay?: number): object;
+    export const minCustomCliVersion: string;
+    export let defaultJfrogCliVersion: string;
+    export const fallbackCliVersion: string;
+    export const pipelineRequestedCliVersionEnv: string;
+    export const taskSelectedCliVersionEnv: string;
+    export const extractorsRemoteEnv: string;
+    export const jfrogCliToolName: string;
 }

--- a/jfrog-tasks-utils/utils.d.ts
+++ b/jfrog-tasks-utils/utils.d.ts
@@ -69,8 +69,6 @@ declare module '@jfrog/tasks-utils' {
     export function singleQuote(str: string): string;
     export function syncRequestWithRetry(method: string, url: string, options?: object, maxRetries?: number, retryDelay?: number): object;
     export const minCustomCliVersion: string;
-    export let defaultJfrogCliVersion: string;
-    export const fallbackCliVersion: string;
     export const pipelineRequestedCliVersionEnv: string;
     export const taskSelectedCliVersionEnv: string;
     export const extractorsRemoteEnv: string;

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -445,27 +445,40 @@ function debugLogIDToken(oidcToken) {
 /**
  * Builds HTTP request options with proxy configuration.
  * Checks Azure DevOps agent proxy variables first, then falls back to
- * typed-rest-client's automatic detection of HTTP_PROXY/HTTPS_PROXY env vars.
+ * HTTPS_PROXY / HTTP_PROXY environment variables.
  * @returns {object} Request options for typed-rest-client HttpClient
  */
 function getProxyConfiguration() {
-    const proxyUrl = tl.getVariable('Agent.ProxyUrl');
+    let proxyUrl = tl.getVariable('Agent.ProxyUrl');
+    let proxyUsername;
+    let proxyPassword;
+    let proxyBypassHosts;
+
+    if (proxyUrl) {
+        tl.debug('Using proxy from Agent.ProxyUrl: ' + proxyUrl);
+        proxyUsername = tl.getVariable('Agent.ProxyUsername');
+        proxyPassword = tl.getVariable('Agent.ProxyPassword');
+        const bypassList = tl.getVariable('Agent.ProxyBypassList');
+        proxyBypassHosts = bypassList ? JSON.parse(bypassList) : undefined;
+    } else {
+        proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy;
+        if (proxyUrl) {
+            tl.debug('Using proxy from environment variable: ' + proxyUrl);
+        }
+    }
+
     if (!proxyUrl) {
         return {};
     }
-    tl.debug('Using proxy from Agent.ProxyUrl: ' + proxyUrl);
-    const proxyUsername = tl.getVariable('Agent.ProxyUsername');
-    const proxyPassword = tl.getVariable('Agent.ProxyPassword');
-    const proxyBypassHosts = tl.getVariable('Agent.ProxyBypassList');
-    const config = {
+
+    return {
         proxy: {
             proxyUrl: proxyUrl,
             proxyUsername: proxyUsername || undefined,
             proxyPassword: proxyPassword || undefined,
-            proxyBypassHosts: proxyBypassHosts ? JSON.parse(proxyBypassHosts) : undefined,
+            proxyBypassHosts: proxyBypassHosts || undefined,
         },
     };
-    return config;
 }
 
 async function fetchAzureOidcToken(serviceConnectionID) {

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -470,8 +470,9 @@ function forwardProxyToEnv() {
             parsed.password = proxyPassword;
             proxyUrl = parsed.toString();
         } catch (e) {
-            tl.warning('Failed to parse proxy URL: ' + e.message);
-            return;
+            tl.warning('Failed to parse proxy URL, credentials will not be included: ' + e.message);
+            // Fall through with the original URL (without credentials) so proxy
+            // support is not lost entirely due to a malformed URL.
         }
     }
 
@@ -490,6 +491,15 @@ function forwardProxyToEnv() {
  * Builds HTTP request options with proxy configuration.
  * Checks Azure DevOps agent proxy variables first, then falls back to
  * HTTPS_PROXY / HTTP_PROXY environment variables.
+ *
+ * Dual-source note: when Agent.ProxyUrl is set, this function reads it directly
+ * for the typed-rest-client request (OIDC token fetch). forwardProxyToEnv()
+ * separately forwards Agent.ProxyUrl into HTTP_PROXY / HTTPS_PROXY so that
+ * JFrog CLI and other child processes pick it up. If a user has also set
+ * HTTP_PROXY manually (and it differs from Agent.ProxyUrl), typed-rest-client
+ * will use Agent.ProxyUrl while JFrog CLI will use the existing env var — by
+ * design, since forwardProxyToEnv() never overrides a pre-existing env var.
+ *
  * @returns {object} Request options for typed-rest-client HttpClient
  */
 function getProxyConfiguration() {
@@ -545,7 +555,7 @@ async function fetchAzureOidcToken(serviceConnectionID) {
 
     const url = `${uri}${teamPrjID}/_apis/distributedtask/hubs/${hub}/plans/${planID}/jobs/${jobID}/oidctoken?api-version=${apiVersion}&serviceConnectionId=${serviceConnectionID}`;
 
-    const requestOptions = getProxyConfiguration();
+    const requestOptions = { ...getProxyConfiguration(), socketTimeout: 30000 };
     const httpClient = new httpm.HttpClient(buildAgent, [new credentialsHandler.BearerCredentialHandler(token, false)], requestOptions);
     tl.debug('Requesting OIDC token from: ' + url);
     const response = await httpClient.post(url, JSON.stringify({}), {

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -460,7 +460,8 @@ function getProxyConfiguration() {
     const config = {
         proxy: {
             proxyUrl: proxyUrl,
-            proxyAuth: proxyUsername && proxyPassword ? `${proxyUsername}:${proxyPassword}` : undefined,
+            proxyUsername: proxyUsername || undefined,
+            proxyPassword: proxyPassword || undefined,
             proxyBypassHosts: proxyBypassHosts ? JSON.parse(proxyBypassHosts) : undefined,
         },
     };

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -48,7 +48,9 @@ function syncRequestWithRetry(method, url, options = {}, maxRetries = 3, retryDe
         if (attempt < maxRetries) {
             // Blocking delay before retry
             const waitUntil = Date.now() + retryDelay;
-            while (Date.now() < waitUntil) { /* wait */ }
+            while (Date.now() < waitUntil) {
+                /* wait */
+            }
         }
     }
 
@@ -220,7 +222,9 @@ module.exports = {
     configureArtifactoryCliServer: configureArtifactoryCliServer,
     configureJfrogCliServer: configureJfrogCliServer,
     configureDefaultJfrogServer: configureDefaultJfrogServer,
+    forwardProxyToEnv: forwardProxyToEnv,
     getProxyConfiguration: getProxyConfiguration,
+    fetchAzureOidcToken: fetchAzureOidcToken,
     configureDefaultArtifactoryServer: configureDefaultArtifactoryServer,
     configureDefaultDistributionServer: configureDefaultDistributionServer,
     configureDefaultXrayServer: configureDefaultXrayServer,
@@ -248,6 +252,9 @@ function executeCliTask(runTaskFunc, cliVersion, cliDownloadUrl, cliAuthHandlers
     process.env.JFROG_CLI_OFFER_CONFIG = 'false';
     process.env.JFROG_CLI_USER_AGENT = buildAgent + '/' + pluginVersion;
     process.env.CI = 'true';
+
+    // Forward Azure DevOps proxy settings to environment variables
+    forwardProxyToEnv();
 
     if (!cliVersion) {
         // If CLI version is passed, use it. Otherwise, use requested version from env var if set. Else, default version.
@@ -443,6 +450,43 @@ function debugLogIDToken(oidcToken) {
 }
 
 /**
+ * Forwards Azure DevOps proxy configuration to environment variables.
+ * Sets HTTP_PROXY and HTTPS_PROXY if they are not already set, allowing
+ * JFrog CLI and other tools to use the proxy configuration.
+ */
+function forwardProxyToEnv() {
+    let proxyUrl = tl.getVariable('Agent.ProxyUrl');
+    if (!proxyUrl) {
+        return;
+    }
+
+    // Build proxy URL with auth if provided
+    let proxyUsername = tl.getVariable('Agent.ProxyUsername');
+    let proxyPassword = tl.getVariable('Agent.ProxyPassword');
+    if (proxyUsername && proxyPassword) {
+        try {
+            let parsed = new URL(proxyUrl);
+            parsed.username = proxyUsername;
+            parsed.password = proxyPassword;
+            proxyUrl = parsed.toString();
+        } catch (e) {
+            tl.warning('Failed to parse proxy URL: ' + e.message);
+            return;
+        }
+    }
+
+    // Only set if not already present — don't override explicit user config
+    if (!process.env.HTTP_PROXY && !process.env.http_proxy) {
+        process.env.HTTP_PROXY = proxyUrl;
+        tl.debug('Set HTTP_PROXY from Agent.ProxyUrl');
+    }
+    if (!process.env.HTTPS_PROXY && !process.env.https_proxy) {
+        process.env.HTTPS_PROXY = proxyUrl;
+        tl.debug('Set HTTPS_PROXY from Agent.ProxyUrl');
+    }
+}
+
+/**
  * Builds HTTP request options with proxy configuration.
  * Checks Azure DevOps agent proxy variables first, then falls back to
  * HTTPS_PROXY / HTTP_PROXY environment variables.
@@ -459,7 +503,12 @@ function getProxyConfiguration() {
         proxyUsername = tl.getVariable('Agent.ProxyUsername');
         proxyPassword = tl.getVariable('Agent.ProxyPassword');
         const bypassList = tl.getVariable('Agent.ProxyBypassList');
-        proxyBypassHosts = bypassList ? JSON.parse(bypassList) : undefined;
+        try {
+            proxyBypassHosts = bypassList ? JSON.parse(bypassList) : undefined;
+        } catch (e) {
+            tl.warning('Failed to parse Agent.ProxyBypassList as JSON: ' + e.message);
+            proxyBypassHosts = undefined;
+        }
     } else {
         proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy;
         if (proxyUrl) {

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -4,6 +4,7 @@ const { join, sep, isAbsolute } = require('path');
 const execSync = require('child_process').execSync;
 const toolLib = require('azure-pipelines-tool-lib/tool');
 const credentialsHandler = require('typed-rest-client/Handlers');
+const httpm = require('typed-rest-client/HttpClient');
 const findJavaHome = require('azure-pipelines-tasks-java-common/java-common').findJavaHome;
 const syncRequest = require('sync-request');
 const semver = require('semver');
@@ -219,6 +220,7 @@ module.exports = {
     configureArtifactoryCliServer: configureArtifactoryCliServer,
     configureJfrogCliServer: configureJfrogCliServer,
     configureDefaultJfrogServer: configureDefaultJfrogServer,
+    getProxyConfiguration: getProxyConfiguration,
     configureDefaultArtifactoryServer: configureDefaultArtifactoryServer,
     configureDefaultDistributionServer: configureDefaultDistributionServer,
     configureDefaultXrayServer: configureDefaultXrayServer,
@@ -259,8 +261,8 @@ function executeCliTask(runTaskFunc, cliVersion, cliDownloadUrl, cliAuthHandlers
 
     runTaskCbk = runTaskFunc;
     getCliPath(cliDownloadUrl, cliAuthHandlers, cliVersion)
-        .then((cliPath) => {
-            runCbk(cliPath);
+        .then(async (cliPath) => {
+            await runCbk(cliPath);
             collectEnvVarsIfNeeded(cliPath);
         })
         .catch((error) => tl.setResult(tl.TaskResult.Failed, 'Error occurred while executing task: ' + error));
@@ -387,8 +389,25 @@ function maskSecrets(str) {
         .replace(/--access-token='.*?'/g, '--access-token=***');
 }
 
-function configureJfrogCliServer(jfrogService, serverId, cliPath, buildDir) {
-    return configureSpecificCliServer(jfrogService, '--url', serverId, cliPath, buildDir);
+async function configureJfrogCliServer(jfrogService, serverId, cliPath, buildDir) {
+    let oidcProviderName = tl.getEndpointAuthorizationParameter(jfrogService, 'oidcProviderName', true);
+    let oidcAccessToken;
+
+    if (oidcProviderName) {
+        let serviceUrl = tl.getEndpointUrl(jfrogService, false);
+        let platformUrl = '';
+        try {
+            platformUrl = tl.getEndpointAuthorizationParameter(jfrogService, 'jfrogPlatformUrl', true);
+        } catch (error) {
+            console.warn('Failed to get platform url from field: ' + error + '\nparsing from url instead');
+        }
+        if (!platformUrl || !platformUrl.trim()) {
+            platformUrl = parsePlatformUrlFromServiceUrl(serviceUrl);
+        }
+        oidcAccessToken = await exchangeOidcTokenAndSetStepVariables(jfrogService, platformUrl, oidcProviderName, cliPath, buildDir);
+    }
+
+    return configureSpecificCliServer(jfrogService, '--url', serverId, cliPath, buildDir, oidcAccessToken);
 }
 
 function configureArtifactoryCliServer(artifactoryService, serverId, cliPath, buildDir) {
@@ -423,7 +442,32 @@ function debugLogIDToken(oidcToken) {
     console.debug('OIDC Token Audience: ', oidcClaims.aud);
 }
 
-function fetchAzureOidcToken(serviceConnectionID) {
+/**
+ * Builds HTTP request options with proxy configuration.
+ * Checks Azure DevOps agent proxy variables first, then falls back to
+ * typed-rest-client's automatic detection of HTTP_PROXY/HTTPS_PROXY env vars.
+ * @returns {object} Request options for typed-rest-client HttpClient
+ */
+function getProxyConfiguration() {
+    const proxyUrl = tl.getVariable('Agent.ProxyUrl');
+    if (!proxyUrl) {
+        return {};
+    }
+    tl.debug('Using proxy from Agent.ProxyUrl: ' + proxyUrl);
+    const proxyUsername = tl.getVariable('Agent.ProxyUsername');
+    const proxyPassword = tl.getVariable('Agent.ProxyPassword');
+    const proxyBypassHosts = tl.getVariable('Agent.ProxyBypassList');
+    const config = {
+        proxy: {
+            proxyUrl: proxyUrl,
+            proxyAuth: proxyUsername && proxyPassword ? `${proxyUsername}:${proxyPassword}` : undefined,
+            proxyBypassHosts: proxyBypassHosts ? JSON.parse(proxyBypassHosts) : undefined,
+        },
+    };
+    return config;
+}
+
+async function fetchAzureOidcToken(serviceConnectionID) {
     const uri = tl.getVariable('System.CollectionUri');
     const teamPrjID = tl.getVariable('System.TeamProjectId');
     const hub = tl.getVariable('System.HostType');
@@ -438,18 +482,21 @@ function fetchAzureOidcToken(serviceConnectionID) {
 
     const url = `${uri}${teamPrjID}/_apis/distributedtask/hubs/${hub}/plans/${planID}/jobs/${jobID}/oidctoken?api-version=${apiVersion}&serviceConnectionId=${serviceConnectionID}`;
 
-    const res = syncRequest('POST', url, {
-        headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-        },
+    const requestOptions = getProxyConfiguration();
+    const httpClient = new httpm.HttpClient(buildAgent, [new credentialsHandler.BearerCredentialHandler(token, false)], requestOptions);
+    tl.debug('Requesting OIDC token from: ' + url);
+    const response = await httpClient.post(url, JSON.stringify({}), {
+        'Content-Type': 'application/json',
     });
 
-    if (res.statusCode !== 200) {
-        throw new Error(`OIDC token request failed: HTTP ${res.statusCode}\nBody: ${res.getBody('utf8')}`);
+    const statusCode = response.message.statusCode;
+    const responseBody = await response.readBody();
+
+    if (statusCode !== 200) {
+        throw new Error(`OIDC token request failed: HTTP ${statusCode}\nBody: ${responseBody}`);
     }
     /** @type {{ oidcToken?: string }} */
-    const body = JSON.parse(res.getBody('utf8'));
+    const body = JSON.parse(responseBody);
     if (!body.oidcToken) {
         throw new Error('OIDC token not found in response body.');
     }
@@ -457,7 +504,7 @@ function fetchAzureOidcToken(serviceConnectionID) {
     return body.oidcToken;
 }
 
-function exchangeOidcTokenAndSetStepVariables(service, serviceUrl, oidcProviderName, cliPath, buildDir) {
+async function exchangeOidcTokenAndSetStepVariables(service, serviceUrl, oidcProviderName, cliPath, buildDir) {
     // First validate supported CLI version
     let cliVersion = getCliVersion(cliPath);
     if (semver.lt(cliVersion, '2.75.0')) {
@@ -470,7 +517,7 @@ function exchangeOidcTokenAndSetStepVariables(service, serviceUrl, oidcProviderN
     }
     let oidcAudience = tl.getEndpointAuthorizationParameter(service, 'oidcAudience', true) || 'api://AzureADTokenExchange';
     const repoName = tl.getVariable('Build.Repository.Name');
-    const idToken = fetchAzureOidcToken(service);
+    const idToken = await fetchAzureOidcToken(service);
 
     // Build the CLI command
     let cliCommand = cliJoin(
@@ -535,33 +582,14 @@ function extractAccessTokenAndUsername(output) {
     throw new Error('Failed to extract AccessToken or Username from the output.');
 }
 
-function configureSpecificCliServer(service, urlFlag, serverId, cliPath, buildDir) {
+function configureSpecificCliServer(service, urlFlag, serverId, cliPath, buildDir, oidcAccessToken) {
     let serviceUrl = tl.getEndpointUrl(service, false);
     let serviceUser = tl.getEndpointAuthorizationParameter(service, 'username', true);
     let servicePassword = tl.getEndpointAuthorizationParameter(service, 'password', true);
-    let serviceAccessToken = tl.getEndpointAuthorizationParameter(service, 'apitoken', true);
-    let oidcProviderName = tl.getEndpointAuthorizationParameter(service, 'oidcProviderName', true);
+    let serviceAccessToken = oidcAccessToken || tl.getEndpointAuthorizationParameter(service, 'apitoken', true);
     let cliCommand = cliJoin(cliPath, jfrogCliConfigAddCommand, quote(serverId), urlFlag + '=' + quote(serviceUrl), '--interactive=false');
     let stdinSecret;
     let secretInStdinSupported = isStdinSecretSupported();
-
-    // In the case of OIDC, we exchange tokens via the CLI
-    // and populate the access token to the CLI config.
-    // This is done by the exchange command and not the config to export
-    // username and access token params for further use by the users.
-    if (oidcProviderName) {
-        // we need platform url for oidc token exchange
-        let platformUrl = '';
-        try {
-            platformUrl = tl.getEndpointAuthorizationParameter(service, 'jfrogPlatformUrl', true);
-        } catch (error) {
-            console.warn('Failed to get platform url from field: ' + error + '\nparsing from url instead');
-        }
-        if (!platformUrl || !platformUrl.trim()) {
-            platformUrl = parsePlatformUrlFromServiceUrl(serviceUrl);
-        }
-        serviceAccessToken = exchangeOidcTokenAndSetStepVariables(service, platformUrl, oidcProviderName, cliPath, buildDir);
-    }
 
     if (serviceAccessToken) {
         // Add access-token if required.
@@ -587,12 +615,12 @@ function configureSpecificCliServer(service, urlFlag, serverId, cliPath, buildDi
  * @param workDir - Working directory.
  * @returns {boolean} - Whether the server was configured or not.
  */
-function configureDefaultJfrogServer(serverId, cliPath, workDir) {
+async function configureDefaultJfrogServer(serverId, cliPath, workDir) {
     let jfrogPlatformService = tl.getInput('jfrogPlatformConnection', false);
     if (!jfrogPlatformService) {
         return false;
     }
-    configureJfrogCliServer(jfrogPlatformService, serverId, cliPath, workDir);
+    await configureJfrogCliServer(jfrogPlatformService, serverId, cliPath, workDir);
     useCliServer(serverId, cliPath, workDir);
     return true;
 }
@@ -787,10 +815,10 @@ function getCliVersion(cliPath) {
     return String.fromCharCode.apply(null, res).split(' ')[2].trim();
 }
 
-function runCbk(cliPath) {
+async function runCbk(cliPath) {
     console.log('Running jfrog-cli from ' + cliPath);
     logCliVersionAndSetSelected(cliPath);
-    runTaskCbk(cliPath);
+    await runTaskCbk(cliPath);
 }
 
 function createCliDirs() {

--- a/tasks/JFrogCliV2/jfrogCliRun.js
+++ b/tasks/JFrogCliV2/jfrogCliRun.js
@@ -27,7 +27,7 @@ function RunJfrogCliCommand(RunTaskCbk) {
     utils.executeCliTask(RunTaskCbk, cliVersion);
 }
 
-function RunTaskCbk(cliPath) {
+async function RunTaskCbk(cliPath) {
     let defaultWorkDir = tl.getVariable('System.DefaultWorkingDirectory');
     if (!defaultWorkDir) {
         tl.setResult(tl.TaskResult.Failed, 'Failed getting default working directory.');
@@ -47,7 +47,7 @@ function RunTaskCbk(cliPath) {
     process.env.JFROG_CLI_BUILD_NUMBER = tl.getVariable('Build.BuildNumber');
 
     serverId = utils.assembleUniqueServerId('jfrog_cli_cmd');
-    utils.configureDefaultJfrogServer(serverId, cliPath, requiredWorkDir);
+    await utils.configureDefaultJfrogServer(serverId, cliPath, requiredWorkDir);
 
     let cliCommandsList = tl.getInput('command', true).split('\n');
     try {

--- a/tests/proxyConfigTest.js
+++ b/tests/proxyConfigTest.js
@@ -211,14 +211,16 @@ runTest('forwardProxyToEnv does not override existing lowercase https_proxy', ()
     clearProxyVars();
 });
 
-runTest('forwardProxyToEnv handles invalid proxy URL gracefully', () => {
+runTest('forwardProxyToEnv falls back to original URL when parse fails (no credentials)', () => {
     clearProxyVars();
     tl.setVariable('Agent.ProxyUrl', 'not-a-valid-url');
     tl.setVariable('Agent.ProxyUsername', 'user');
     tl.setVariable('Agent.ProxyPassword', 'pass');
     jfrogUtils.forwardProxyToEnv();
-    assert.strictEqual(process.env.HTTP_PROXY, undefined);
-    assert.strictEqual(process.env.HTTPS_PROXY, undefined);
+    // URL parsing fails so credentials cannot be embedded, but the original
+    // URL is still forwarded so proxy support is not lost entirely.
+    assert.strictEqual(process.env.HTTP_PROXY, 'not-a-valid-url');
+    assert.strictEqual(process.env.HTTPS_PROXY, 'not-a-valid-url');
     clearProxyVars();
 });
 

--- a/tests/proxyConfigTest.js
+++ b/tests/proxyConfigTest.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 const tl = require('azure-pipelines-task-lib/task');
 const jfrogUtils = require('../jfrog-tasks-utils/utils.js');
 const assert = require('assert');
@@ -22,6 +23,10 @@ function clearProxyVars() {
     tl.setVariable('Agent.ProxyUsername', '');
     tl.setVariable('Agent.ProxyPassword', '');
     tl.setVariable('Agent.ProxyBypassList', '');
+    delete process.env.HTTPS_PROXY;
+    delete process.env.https_proxy;
+    delete process.env.HTTP_PROXY;
+    delete process.env.http_proxy;
 }
 
 console.log('\nProxy Configuration Tests\n');
@@ -83,6 +88,46 @@ runTest('Handles HTTPS proxy URL', () => {
     const config = jfrogUtils.getProxyConfiguration();
     assert.strictEqual(config.proxy.proxyUrl, 'https://secureproxy:443');
     clearProxyVars();
+});
+
+runTest('Falls back to HTTPS_PROXY env var when Agent.ProxyUrl is not set', () => {
+    clearProxyVars();
+    process.env.HTTPS_PROXY = 'http://envproxy:8100';
+    const config = jfrogUtils.getProxyConfiguration();
+    assert.strictEqual(config.proxy.proxyUrl, 'http://envproxy:8100');
+    assert.strictEqual(config.proxy.proxyUsername, undefined);
+    clearProxyVars();
+});
+
+runTest('Falls back to HTTP_PROXY env var when HTTPS_PROXY is not set', () => {
+    clearProxyVars();
+    process.env.HTTP_PROXY = 'http://httpproxy:3128';
+    const config = jfrogUtils.getProxyConfiguration();
+    assert.strictEqual(config.proxy.proxyUrl, 'http://httpproxy:3128');
+    clearProxyVars();
+});
+
+runTest('Falls back to lowercase https_proxy env var', () => {
+    clearProxyVars();
+    process.env.https_proxy = 'http://lowercaseproxy:9090';
+    const config = jfrogUtils.getProxyConfiguration();
+    assert.strictEqual(config.proxy.proxyUrl, 'http://lowercaseproxy:9090');
+    clearProxyVars();
+});
+
+runTest('Agent.ProxyUrl takes priority over HTTPS_PROXY env var', () => {
+    clearProxyVars();
+    tl.setVariable('Agent.ProxyUrl', 'http://agentproxy:3128');
+    process.env.HTTPS_PROXY = 'http://envproxy:8100';
+    const config = jfrogUtils.getProxyConfiguration();
+    assert.strictEqual(config.proxy.proxyUrl, 'http://agentproxy:3128');
+    clearProxyVars();
+});
+
+runTest('Returns empty object when no proxy is configured anywhere', () => {
+    clearProxyVars();
+    const config = jfrogUtils.getProxyConfiguration();
+    assert.deepStrictEqual(config, {});
 });
 
 console.log(`\nResults: ${passed} passed, ${failed} failed\n`);

--- a/tests/proxyConfigTest.js
+++ b/tests/proxyConfigTest.js
@@ -19,10 +19,10 @@ function runTest(name, fn) {
 }
 
 function clearProxyVars() {
-    tl.setVariable('Agent.ProxyUrl', '');
-    tl.setVariable('Agent.ProxyUsername', '');
-    tl.setVariable('Agent.ProxyPassword', '');
-    tl.setVariable('Agent.ProxyBypassList', '');
+    tl.setVariable('Agent.ProxyUrl', undefined);
+    tl.setVariable('Agent.ProxyUsername', undefined);
+    tl.setVariable('Agent.ProxyPassword', undefined);
+    tl.setVariable('Agent.ProxyBypassList', undefined);
     delete process.env.HTTPS_PROXY;
     delete process.env.https_proxy;
     delete process.env.HTTP_PROXY;
@@ -128,6 +128,98 @@ runTest('Returns empty object when no proxy is configured anywhere', () => {
     clearProxyVars();
     const config = jfrogUtils.getProxyConfiguration();
     assert.deepStrictEqual(config, {});
+});
+
+runTest('Returns undefined proxyBypassHosts when Agent.ProxyBypassList contains invalid JSON', () => {
+    clearProxyVars();
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    tl.setVariable('Agent.ProxyBypassList', 'not-valid-json');
+    const config = jfrogUtils.getProxyConfiguration();
+    assert.strictEqual(config.proxy.proxyBypassHosts, undefined);
+    clearProxyVars();
+});
+
+console.log('\nforwardProxyToEnv Tests\n');
+
+runTest('forwardProxyToEnv does nothing when Agent.ProxyUrl is not set', () => {
+    clearProxyVars();
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.HTTP_PROXY, undefined);
+    assert.strictEqual(process.env.HTTPS_PROXY, undefined);
+    clearProxyVars();
+});
+
+runTest('forwardProxyToEnv sets HTTP_PROXY and HTTPS_PROXY when Agent.ProxyUrl is set', () => {
+    clearProxyVars();
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.HTTP_PROXY, 'http://myproxy:8080');
+    assert.strictEqual(process.env.HTTPS_PROXY, 'http://myproxy:8080');
+    clearProxyVars();
+});
+
+runTest('forwardProxyToEnv includes auth in proxy URL when username and password are set', () => {
+    clearProxyVars();
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    tl.setVariable('Agent.ProxyUsername', 'user');
+    tl.setVariable('Agent.ProxyPassword', 'pass');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.HTTP_PROXY, 'http://user:pass@myproxy:8080/');
+    assert.strictEqual(process.env.HTTPS_PROXY, 'http://user:pass@myproxy:8080/');
+    clearProxyVars();
+});
+
+runTest('forwardProxyToEnv does not override existing HTTP_PROXY', () => {
+    clearProxyVars();
+    process.env.HTTP_PROXY = 'http://existing:9090';
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.HTTP_PROXY, 'http://existing:9090');
+    assert.strictEqual(process.env.HTTPS_PROXY, 'http://myproxy:8080');
+    clearProxyVars();
+});
+
+runTest('forwardProxyToEnv does not override existing HTTPS_PROXY', () => {
+    clearProxyVars();
+    process.env.HTTPS_PROXY = 'http://existing:9090';
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.HTTP_PROXY, 'http://myproxy:8080');
+    assert.strictEqual(process.env.HTTPS_PROXY, 'http://existing:9090');
+    clearProxyVars();
+});
+
+runTest('forwardProxyToEnv does not override existing lowercase http_proxy', () => {
+    clearProxyVars();
+    process.env.http_proxy = 'http://existing:9090';
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.http_proxy, 'http://existing:9090');
+    assert.strictEqual(process.env.HTTP_PROXY, undefined);
+    assert.strictEqual(process.env.HTTPS_PROXY, 'http://myproxy:8080');
+    clearProxyVars();
+});
+
+runTest('forwardProxyToEnv does not override existing lowercase https_proxy', () => {
+    clearProxyVars();
+    process.env.https_proxy = 'http://existing:9090';
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.https_proxy, 'http://existing:9090');
+    assert.strictEqual(process.env.HTTPS_PROXY, undefined);
+    assert.strictEqual(process.env.HTTP_PROXY, 'http://myproxy:8080');
+    clearProxyVars();
+});
+
+runTest('forwardProxyToEnv handles invalid proxy URL gracefully', () => {
+    clearProxyVars();
+    tl.setVariable('Agent.ProxyUrl', 'not-a-valid-url');
+    tl.setVariable('Agent.ProxyUsername', 'user');
+    tl.setVariable('Agent.ProxyPassword', 'pass');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.HTTP_PROXY, undefined);
+    assert.strictEqual(process.env.HTTPS_PROXY, undefined);
+    clearProxyVars();
 });
 
 console.log(`\nResults: ${passed} passed, ${failed} failed\n`);

--- a/tests/proxyConfigTest.js
+++ b/tests/proxyConfigTest.js
@@ -1,0 +1,89 @@
+const tl = require('azure-pipelines-task-lib/task');
+const jfrogUtils = require('../jfrog-tasks-utils/utils.js');
+const assert = require('assert');
+
+let passed = 0;
+let failed = 0;
+
+function runTest(name, fn) {
+    try {
+        fn();
+        console.log(`  ✓ ${name}`);
+        passed++;
+    } catch (err) {
+        console.error(`  ✗ ${name}`);
+        console.error(`    ${err.message}`);
+        failed++;
+    }
+}
+
+function clearProxyVars() {
+    tl.setVariable('Agent.ProxyUrl', '');
+    tl.setVariable('Agent.ProxyUsername', '');
+    tl.setVariable('Agent.ProxyPassword', '');
+    tl.setVariable('Agent.ProxyBypassList', '');
+}
+
+console.log('\nProxy Configuration Tests\n');
+
+runTest('Returns empty object when no proxy is set', () => {
+    clearProxyVars();
+    const config = jfrogUtils.getProxyConfiguration();
+    assert.deepStrictEqual(config, {});
+});
+
+runTest('Returns proxy config with URL only', () => {
+    clearProxyVars();
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    const config = jfrogUtils.getProxyConfiguration();
+    assert.strictEqual(config.proxy.proxyUrl, 'http://myproxy:8080');
+    assert.strictEqual(config.proxy.proxyUsername, undefined);
+    assert.strictEqual(config.proxy.proxyPassword, undefined);
+    assert.strictEqual(config.proxy.proxyBypassHosts, undefined);
+    clearProxyVars();
+});
+
+runTest('Returns full proxy config with auth and bypass list', () => {
+    clearProxyVars();
+    tl.setVariable('Agent.ProxyUrl', 'http://corpproxy:3128');
+    tl.setVariable('Agent.ProxyUsername', 'proxyuser');
+    tl.setVariable('Agent.ProxyPassword', 'proxypass');
+    tl.setVariable('Agent.ProxyBypassList', '["localhost","*.internal.corp"]');
+    const config = jfrogUtils.getProxyConfiguration();
+    assert.strictEqual(config.proxy.proxyUrl, 'http://corpproxy:3128');
+    assert.strictEqual(config.proxy.proxyUsername, 'proxyuser');
+    assert.strictEqual(config.proxy.proxyPassword, 'proxypass');
+    assert.deepStrictEqual(config.proxy.proxyBypassHosts, ['localhost', '*.internal.corp']);
+    clearProxyVars();
+});
+
+runTest('proxyUsername/proxyPassword are undefined when not set', () => {
+    clearProxyVars();
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    tl.setVariable('Agent.ProxyUsername', 'user');
+    const config = jfrogUtils.getProxyConfiguration();
+    assert.strictEqual(config.proxy.proxyUsername, 'user');
+    assert.strictEqual(config.proxy.proxyPassword, undefined);
+    clearProxyVars();
+});
+
+runTest('proxyPassword without username still passes both separately', () => {
+    clearProxyVars();
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    tl.setVariable('Agent.ProxyPassword', 'pass');
+    const config = jfrogUtils.getProxyConfiguration();
+    assert.strictEqual(config.proxy.proxyUsername, undefined);
+    assert.strictEqual(config.proxy.proxyPassword, 'pass');
+    clearProxyVars();
+});
+
+runTest('Handles HTTPS proxy URL', () => {
+    clearProxyVars();
+    tl.setVariable('Agent.ProxyUrl', 'https://secureproxy:443');
+    const config = jfrogUtils.getProxyConfiguration();
+    assert.strictEqual(config.proxy.proxyUrl, 'https://secureproxy:443');
+    clearProxyVars();
+});
+
+console.log(`\nResults: ${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/utilsTests.ts
+++ b/tests/utilsTests.ts
@@ -4,7 +4,7 @@ import * as assert from 'assert';
 // Use require to get the actual module with latest exports
 import * as jfrogUtils from '@jfrog/tasks-utils';
 
-// Type declarations for the new exported functions
+// Type declarations for exports not yet in the installed package's utils.d.ts
 declare module '@jfrog/tasks-utils' {
     export function syncRequestWithRetry(
         method: string,

--- a/tests/utilsTests.ts
+++ b/tests/utilsTests.ts
@@ -17,6 +17,7 @@ declare module '@jfrog/tasks-utils' {
     export function fetchLatestCliVersion(): string;
     export const defaultJfrogCliVersion: string;
     export const fallbackCliVersion: string;
+    export function fetchAzureOidcToken(serviceConnectionID: string): Promise<string>;
 }
 
 /**
@@ -162,21 +163,15 @@ describe('Utils Unit Tests', (): void => {
         });
 
         it('should throw error after retries exhausted on 5xx server error', (): void => {
-            assert.throws(
-                (): void => {
-                    jfrogUtils.syncRequestWithRetry('GET', 'https://httpstat.us/503', { timeout: 5000 }, 2, 100);
-                },
-                /Server error 503 after 2 retries/,
-            );
+            assert.throws((): void => {
+                jfrogUtils.syncRequestWithRetry('GET', 'https://httpstat.us/503', { timeout: 5000 }, 2, 100);
+            }, /Server error 503 after 2 retries/);
         });
 
         it('should throw error on network failure after retries', (): void => {
-            assert.throws(
-                (): void => {
-                    jfrogUtils.syncRequestWithRetry('GET', 'https://invalid.domain.that.does.not.exist.example', { timeout: 1000 }, 2, 100);
-                },
-                Error,
-            );
+            assert.throws((): void => {
+                jfrogUtils.syncRequestWithRetry('GET', 'https://invalid.domain.that.does.not.exist.example', { timeout: 1000 }, 2, 100);
+            }, Error);
         });
     });
 
@@ -239,6 +234,67 @@ describe('Utils Unit Tests', (): void => {
             // The fallback version should always have its binary available
             const result: boolean = jfrogUtils.isCliBinaryAvailable(jfrogUtils.fallbackCliVersion);
             assert.strictEqual(result, true, `Fallback version ${jfrogUtils.fallbackCliVersion} should have available binary`);
+        });
+    });
+
+    describe('fetchAzureOidcToken', (): void => {
+        /**
+         * Simulates the OIDC token response-handling logic from fetchAzureOidcToken
+         * (the part after the HTTP call is made), so we can unit-test it without
+         * a real Azure DevOps endpoint.
+         */
+        async function simulateOidcTokenResponse(statusCode: number, responseBody: string): Promise<string> {
+            if (statusCode !== 200) {
+                throw new Error(`OIDC token request failed: HTTP ${statusCode}\nBody: ${responseBody}`);
+            }
+            const body: { oidcToken?: string } = JSON.parse(responseBody);
+            if (!body.oidcToken) {
+                throw new Error('OIDC token not found in response body.');
+            }
+            return body.oidcToken;
+        }
+
+        it('should throw when System.AccessToken is not available', async (): Promise<void> => {
+            // System.AccessToken is not set in the test environment, so this should throw immediately.
+            await assert.rejects(
+                (): Promise<string> => jfrogUtils.fetchAzureOidcToken('test-service-connection-id'),
+                /System\.AccessToken is not available/,
+            );
+        });
+
+        it('should throw on non-200 HTTP response (simulated)', async (): Promise<void> => {
+            await assert.rejects((): Promise<string> => simulateOidcTokenResponse(403, 'Forbidden'), /OIDC token request failed: HTTP 403/);
+        });
+
+        it('should throw on 500 HTTP response (simulated)', async (): Promise<void> => {
+            await assert.rejects(
+                (): Promise<string> => simulateOidcTokenResponse(500, 'Internal Server Error'),
+                /OIDC token request failed: HTTP 500/,
+            );
+        });
+
+        it('should throw when oidcToken is absent from response body (simulated)', async (): Promise<void> => {
+            await assert.rejects(
+                (): Promise<string> => simulateOidcTokenResponse(200, JSON.stringify({ someOtherField: 'value' })),
+                /OIDC token not found in response body/,
+            );
+        });
+
+        it('should throw when oidcToken is empty string in response body (simulated)', async (): Promise<void> => {
+            await assert.rejects(
+                (): Promise<string> => simulateOidcTokenResponse(200, JSON.stringify({ oidcToken: '' })),
+                /OIDC token not found in response body/,
+            );
+        });
+
+        it('should return the oidcToken on a successful 200 response (simulated)', async (): Promise<void> => {
+            const token: string = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test';
+            const result: string = await simulateOidcTokenResponse(200, JSON.stringify({ oidcToken: token }));
+            assert.strictEqual(result, token);
+        });
+
+        it('should throw when response body is not valid JSON (simulated)', async (): Promise<void> => {
+            await assert.rejects((): Promise<string> => simulateOidcTokenResponse(200, 'not-json'), SyntaxError);
         });
     });
 });


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
## Add proxy support for OIDC authentication

### Summary

The JFrog Azure DevOps extension now supports proxy configurations when retrieving OIDC tokens from Azure DevOps. Previously, the OIDC token request (`POST https://dev.azure.com/.../_apis/distributedtask/hubs/.../oidctoken`) used the synchronous `sync-request` library, which does not honor proxy settings. This caused OIDC authentication to fail when the Azure DevOps Agent runs behind a proxy.

### Problem

When an Azure DevOps Agent is deployed within an intranet behind a proxy, the extension's OIDC flow fails silently because:
1. `sync-request` does not support proxy configuration.
2. The extension did not read Azure DevOps Agent proxy variables (`Agent.ProxyUrl`, `Agent.ProxyUsername`, `Agent.ProxyPassword`, `Agent.ProxyBypassList`).

### Solution

- Replaced `sync-request` with the async `typed-rest-client/HttpClient` (already a project dependency) for the OIDC token fetch. This client natively supports proxy configuration and automatically respects `HTTP_PROXY`/`HTTPS_PROXY` environment variables.
- Added `getProxyConfiguration()` to explicitly read Azure DevOps Agent proxy variables and pass them to the HTTP client.
- Moved the OIDC resolution logic from `configureSpecificCliServer` (shared by all connection types) into `configureJfrogCliServer` (JFrog platform connections only), keeping the async footprint minimal.

### Async impact

Only the OIDC code path is async. All other connection types (Artifactory, Distribution, Xray) and all other task files remain fully synchronous and unchanged.


### Proxy support matrix

| Proxy source | Supported |
|---|---|
| `HTTP_PROXY` / `HTTPS_PROXY` env vars | Yes (handled automatically by `typed-rest-client`) |
| `Agent.ProxyUrl` / `Agent.ProxyUsername` / `Agent.ProxyPassword` / `Agent.ProxyBypassList` | Yes (handled explicitly by `getProxyConfiguration()`) |