### PR TITLE
Fix cloud instance test

### DIFF
--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -720,7 +720,9 @@ function addStringParam(cliCommand, inputParam, cliParam, require) {
 
 function addBoolParam(cliCommand, inputParam, cliParam) {
     let val = tl.getBoolInput(inputParam, false);
-    cliCommand = cliJoin(cliCommand, '--' + cliParam + '=' + val);
+    if (val !== undefined) {
+        cliCommand = cliJoin(cliCommand, '--' + cliParam + '=' + val);
+    }
     return cliCommand;
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
  ## Fix cloud instance test / guard `addBoolParam` against `undefined`
                                                                                                              
  ### Problem                                                                                                 
  The `addBoolParam` utility in `jfrog-tasks-utils/utils.js` was unconditionally
  appending `--<flag>=false` (or `--<flag>=undefined`) to CLI commands even when                              
  the task input was not set. On cloud instances, several optional bool inputs  
  are absent, causing the JFrog CLI to receive malformed flags and the                                        
  corresponding tests to fail.                                                                                
                                                                                                              
  ### Fix                                                                                                     
  Added an `undefined` guard so the flag is only appended when a value is                                     
  actually present:                                                      
                                                                                                              
  ```js
  if (val !== undefined) {                                                                                    
      cliCommand = cliJoin(cliCommand, '--' + cliParam + '=' + val);
  }                                                                                                           
```                         
### Relation to RTECO-796 (allowFailBuild fix, #589)

PR #589 fixed incorrect behaviour of the allowFailBuild parameter — a bool param that is optional in many task configurations. The root cause traced back to the same addBoolParam helper passing an undefined value through to the CLI. This fix closes that gap at the utility level, preventing similar issues for any other optional bool inputs beyond just allowFailBuild.