### PR TITLE
Update JFrog CLI version to 2.99.0

### DIFF
--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -11,8 +11,8 @@ const semver = require('semver');
 const fileName = getCliExecutableName();
 const jfrogCliToolName = 'jf';
 const cliPackage = 'jfrog-cli-' + getArchitecture();
-const fallbackCliVersion = '2.89.0';
-let defaultJfrogCliVersion = '2.89.0';
+const fallbackCliVersion = '2.99.0';
+let defaultJfrogCliVersion = '2.99.0';
 
 /**
  * Executes an HTTP request with retry logic for 5xx errors.


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Update both `fallbackCliVersion` and `defaultJfrogCliVersion` from `2.89.0` to `2.99.0` to use the latest stable CLI release.
