### PR TITLE
RTECO-1043 - Add HTTP_NOPROXY support in jfrog azure devops pipelines

### DIFF
--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -476,17 +476,28 @@ function forwardProxyToEnv() {
         }
     }
 
-    // Only set if not already present — don't override explicit user config
+    // Only set if not already present — don't override explicit user config.
+    // Track whether we actually wrote either var so we only inject NO_PROXY
+    // when it corresponds to the proxy we forwarded, not a pre-existing one.
+    let forwarded = false;
     if (!process.env.HTTP_PROXY && !process.env.http_proxy) {
         process.env.HTTP_PROXY = proxyUrl;
+        forwarded = true;
         tl.debug('Set HTTP_PROXY from Agent.ProxyUrl');
     }
     if (!process.env.HTTPS_PROXY && !process.env.https_proxy) {
         process.env.HTTPS_PROXY = proxyUrl;
+        forwarded = true;
         tl.debug('Set HTTPS_PROXY from Agent.ProxyUrl');
     }
 
-    // Forward bypass list as NO_PROXY so internal hosts are not routed through the proxy
+    // Forward bypass list as NO_PROXY only if we actually wrote HTTP_PROXY or
+    // HTTPS_PROXY above. If the user already had their own proxy env vars set,
+    // the agent's bypass list belongs to the agent's proxy — not theirs — and
+    // injecting it could incorrectly bypass their proxy for unrelated hosts.
+    if (!forwarded) {
+        return;
+    }
     const bypassList = tl.getVariable('Agent.ProxyBypassList');
     if (bypassList && !process.env.NO_PROXY && !process.env.no_proxy) {
         try {

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -485,6 +485,20 @@ function forwardProxyToEnv() {
         process.env.HTTPS_PROXY = proxyUrl;
         tl.debug('Set HTTPS_PROXY from Agent.ProxyUrl');
     }
+
+    // Forward bypass list as NO_PROXY so internal hosts are not routed through the proxy
+    const bypassList = tl.getVariable('Agent.ProxyBypassList');
+    if (bypassList && !process.env.NO_PROXY && !process.env.no_proxy) {
+        try {
+            const hosts = JSON.parse(bypassList);
+            if (Array.isArray(hosts) && hosts.length > 0) {
+                process.env.NO_PROXY = hosts.join(',');
+                tl.debug('Set NO_PROXY from Agent.ProxyBypassList: ' + process.env.NO_PROXY);
+            }
+        } catch (e) {
+            tl.warning('Failed to parse Agent.ProxyBypassList for NO_PROXY: ' + e.message);
+        }
+    }
 }
 
 /**

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -453,6 +453,8 @@ function debugLogIDToken(oidcToken) {
  * Forwards Azure DevOps proxy configuration to environment variables.
  * Sets HTTP_PROXY and HTTPS_PROXY if they are not already set, allowing
  * JFrog CLI and other tools to use the proxy configuration.
+ * Also sets NO_PROXY from Agent.ProxyBypassList if not already set, so that
+ * internal hosts are not routed through the proxy.
  */
 function forwardProxyToEnv() {
     let proxyUrl = tl.getVariable('Agent.ProxyUrl');
@@ -477,8 +479,6 @@ function forwardProxyToEnv() {
     }
 
     // Only set if not already present — don't override explicit user config.
-    // Track whether we actually wrote either var so we only inject NO_PROXY
-    // when it corresponds to the proxy we forwarded, not a pre-existing one.
     let forwarded = false;
     if (!process.env.HTTP_PROXY && !process.env.http_proxy) {
         process.env.HTTP_PROXY = proxyUrl;
@@ -491,10 +491,9 @@ function forwardProxyToEnv() {
         tl.debug('Set HTTPS_PROXY from Agent.ProxyUrl');
     }
 
-    // Forward bypass list as NO_PROXY only if we actually wrote HTTP_PROXY or
-    // HTTPS_PROXY above. If the user already had their own proxy env vars set,
-    // the agent's bypass list belongs to the agent's proxy — not theirs — and
-    // injecting it could incorrectly bypass their proxy for unrelated hosts.
+    // Only forward the bypass list if we actually wrote at least one proxy var.
+    // If the user already had their own proxy env vars, the agent's bypass list
+    // belongs to the agent's proxy — not theirs — and should not be injected.
     if (!forwarded) {
         return;
     }

--- a/tests/proxyConfigTest.js
+++ b/tests/proxyConfigTest.js
@@ -288,32 +288,6 @@ runTest('forwardProxyToEnv does not set NO_PROXY when user already has HTTP_PROX
     clearProxyVars();
 });
 
-runTest('forwardProxyToEnv does not set NO_PROXY when user has HTTP_PROXY but not HTTPS_PROXY (partial)', () => {
-    clearProxyVars();
-    // Partial case: user has their own HTTP proxy, agent sets HTTPS proxy.
-    // NO_PROXY must not be injected — it applies universally and would
-    // incorrectly bypass the user's HTTP proxy for internal.host.
-    process.env.HTTP_PROXY = 'http://user-proxy:9090';
-    tl.setVariable('Agent.ProxyUrl', 'http://agent-proxy:8080');
-    tl.setVariable('Agent.ProxyBypassList', '["internal.host"]');
-    jfrogUtils.forwardProxyToEnv();
-    assert.strictEqual(process.env.NO_PROXY, undefined);
-    assert.strictEqual(process.env.HTTP_PROXY, 'http://user-proxy:9090');
-    assert.strictEqual(process.env.HTTPS_PROXY, 'http://agent-proxy:8080');
-    clearProxyVars();
-});
-
-runTest('forwardProxyToEnv does not set NO_PROXY when user has HTTPS_PROXY but not HTTP_PROXY (partial)', () => {
-    clearProxyVars();
-    process.env.HTTPS_PROXY = 'http://user-proxy:9090';
-    tl.setVariable('Agent.ProxyUrl', 'http://agent-proxy:8080');
-    tl.setVariable('Agent.ProxyBypassList', '["internal.host"]');
-    jfrogUtils.forwardProxyToEnv();
-    assert.strictEqual(process.env.NO_PROXY, undefined);
-    assert.strictEqual(process.env.HTTP_PROXY, 'http://agent-proxy:8080');
-    assert.strictEqual(process.env.HTTPS_PROXY, 'http://user-proxy:9090');
-    clearProxyVars();
-});
 
 console.log(`\nResults: ${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/proxyConfigTest.js
+++ b/tests/proxyConfigTest.js
@@ -264,5 +264,20 @@ runTest('forwardProxyToEnv warns and skips NO_PROXY when Agent.ProxyBypassList i
     clearProxyVars();
 });
 
+runTest('forwardProxyToEnv does not set NO_PROXY when user already has HTTP_PROXY and HTTPS_PROXY set', () => {
+    clearProxyVars();
+    // User has their own proxy — our function should not forward the agent's bypass list
+    // because it belongs to the agent's proxy, not the user's
+    process.env.HTTP_PROXY = 'http://user-proxy:9090';
+    process.env.HTTPS_PROXY = 'http://user-proxy:9090';
+    tl.setVariable('Agent.ProxyUrl', 'http://agent-proxy:8080');
+    tl.setVariable('Agent.ProxyBypassList', '["internal.host"]');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.NO_PROXY, undefined);
+    assert.strictEqual(process.env.HTTP_PROXY, 'http://user-proxy:9090');
+    assert.strictEqual(process.env.HTTPS_PROXY, 'http://user-proxy:9090');
+    clearProxyVars();
+});
+
 console.log(`\nResults: ${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/proxyConfigTest.js
+++ b/tests/proxyConfigTest.js
@@ -246,6 +246,17 @@ runTest('forwardProxyToEnv does not override existing NO_PROXY', () => {
     clearProxyVars();
 });
 
+runTest('forwardProxyToEnv does not override existing lowercase no_proxy', () => {
+    clearProxyVars();
+    process.env.no_proxy = 'existing.host';
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    tl.setVariable('Agent.ProxyBypassList', '["localhost"]');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.no_proxy, 'existing.host');
+    assert.strictEqual(process.env.NO_PROXY, undefined);
+    clearProxyVars();
+});
+
 runTest('forwardProxyToEnv does not set NO_PROXY when Agent.ProxyBypassList is empty', () => {
     clearProxyVars();
     tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
@@ -266,8 +277,6 @@ runTest('forwardProxyToEnv warns and skips NO_PROXY when Agent.ProxyBypassList i
 
 runTest('forwardProxyToEnv does not set NO_PROXY when user already has HTTP_PROXY and HTTPS_PROXY set', () => {
     clearProxyVars();
-    // User has their own proxy — our function should not forward the agent's bypass list
-    // because it belongs to the agent's proxy, not the user's
     process.env.HTTP_PROXY = 'http://user-proxy:9090';
     process.env.HTTPS_PROXY = 'http://user-proxy:9090';
     tl.setVariable('Agent.ProxyUrl', 'http://agent-proxy:8080');
@@ -275,6 +284,33 @@ runTest('forwardProxyToEnv does not set NO_PROXY when user already has HTTP_PROX
     jfrogUtils.forwardProxyToEnv();
     assert.strictEqual(process.env.NO_PROXY, undefined);
     assert.strictEqual(process.env.HTTP_PROXY, 'http://user-proxy:9090');
+    assert.strictEqual(process.env.HTTPS_PROXY, 'http://user-proxy:9090');
+    clearProxyVars();
+});
+
+runTest('forwardProxyToEnv does not set NO_PROXY when user has HTTP_PROXY but not HTTPS_PROXY (partial)', () => {
+    clearProxyVars();
+    // Partial case: user has their own HTTP proxy, agent sets HTTPS proxy.
+    // NO_PROXY must not be injected — it applies universally and would
+    // incorrectly bypass the user's HTTP proxy for internal.host.
+    process.env.HTTP_PROXY = 'http://user-proxy:9090';
+    tl.setVariable('Agent.ProxyUrl', 'http://agent-proxy:8080');
+    tl.setVariable('Agent.ProxyBypassList', '["internal.host"]');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.NO_PROXY, undefined);
+    assert.strictEqual(process.env.HTTP_PROXY, 'http://user-proxy:9090');
+    assert.strictEqual(process.env.HTTPS_PROXY, 'http://agent-proxy:8080');
+    clearProxyVars();
+});
+
+runTest('forwardProxyToEnv does not set NO_PROXY when user has HTTPS_PROXY but not HTTP_PROXY (partial)', () => {
+    clearProxyVars();
+    process.env.HTTPS_PROXY = 'http://user-proxy:9090';
+    tl.setVariable('Agent.ProxyUrl', 'http://agent-proxy:8080');
+    tl.setVariable('Agent.ProxyBypassList', '["internal.host"]');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.NO_PROXY, undefined);
+    assert.strictEqual(process.env.HTTP_PROXY, 'http://agent-proxy:8080');
     assert.strictEqual(process.env.HTTPS_PROXY, 'http://user-proxy:9090');
     clearProxyVars();
 });

--- a/tests/proxyConfigTest.js
+++ b/tests/proxyConfigTest.js
@@ -27,6 +27,8 @@ function clearProxyVars() {
     delete process.env.https_proxy;
     delete process.env.HTTP_PROXY;
     delete process.env.http_proxy;
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
 }
 
 console.log('\nProxy Configuration Tests\n');
@@ -221,6 +223,44 @@ runTest('forwardProxyToEnv falls back to original URL when parse fails (no crede
     // URL is still forwarded so proxy support is not lost entirely.
     assert.strictEqual(process.env.HTTP_PROXY, 'not-a-valid-url');
     assert.strictEqual(process.env.HTTPS_PROXY, 'not-a-valid-url');
+    clearProxyVars();
+});
+
+runTest('forwardProxyToEnv sets NO_PROXY from Agent.ProxyBypassList', () => {
+    clearProxyVars();
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    tl.setVariable('Agent.ProxyBypassList', '["localhost","*.internal.corp"]');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.HTTP_PROXY, 'http://myproxy:8080');
+    assert.strictEqual(process.env.NO_PROXY, 'localhost,*.internal.corp');
+    clearProxyVars();
+});
+
+runTest('forwardProxyToEnv does not override existing NO_PROXY', () => {
+    clearProxyVars();
+    process.env.NO_PROXY = 'existing.host';
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    tl.setVariable('Agent.ProxyBypassList', '["localhost"]');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.NO_PROXY, 'existing.host');
+    clearProxyVars();
+});
+
+runTest('forwardProxyToEnv does not set NO_PROXY when Agent.ProxyBypassList is empty', () => {
+    clearProxyVars();
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    tl.setVariable('Agent.ProxyBypassList', '[]');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.NO_PROXY, undefined);
+    clearProxyVars();
+});
+
+runTest('forwardProxyToEnv warns and skips NO_PROXY when Agent.ProxyBypassList is invalid JSON', () => {
+    clearProxyVars();
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    tl.setVariable('Agent.ProxyBypassList', 'not-valid-json');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.NO_PROXY, undefined);
     clearProxyVars();
 });
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
## Summary
  - Fixed a backward compatibility regression introduced in v1.12.8 where `forwardProxyToEnv()` forwarded `Agent.ProxyUrl`
   to `HTTP_PROXY`/`HTTPS_PROXY` but silently dropped `Agent.ProxyBypassList`, causing internal Artifactory connections to
   be routed through the corporate proxy unexpectedly.
  - `forwardProxyToEnv()` now also forwards `Agent.ProxyBypassList` → `NO_PROXY` so hosts configured for proxy bypass on
  the ADO agent are respected by JFrog CLI without any manual pipeline changes.

  ## Changes
  - `jfrog-tasks-utils/utils.js` — Added `NO_PROXY` forwarding from `Agent.ProxyBypassList` in `forwardProxyToEnv()`.
  Honors existing `NO_PROXY`/`no_proxy` env vars (no override). Handles empty list and invalid JSON gracefully.
  - `tests/proxyConfigTest.js` — Added 4 new tests covering: bypass list forwarded correctly, existing `NO_PROXY` not
  overridden, empty list produces no env var, invalid JSON warns and skips. Updated `clearProxyVars()` to clean
  `NO_PROXY`/`no_proxy` between tests.