### PR TITLE
Removed automatic forwarding of Agent.ProxyUrl to HTTP_PROXY/HTTPS_PROXY for JFrog CLI

### DIFF
--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -253,9 +253,6 @@ function executeCliTask(runTaskFunc, cliVersion, cliDownloadUrl, cliAuthHandlers
     process.env.JFROG_CLI_USER_AGENT = buildAgent + '/' + pluginVersion;
     process.env.CI = 'true';
 
-    // Forward Azure DevOps proxy settings to environment variables
-    forwardProxyToEnv();
-
     if (!cliVersion) {
         // If CLI version is passed, use it. Otherwise, use requested version from env var if set. Else, default version.
         cliVersion = tl.getVariable(pipelineRequestedCliVersionEnv) || defaultJfrogCliVersion;

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -499,7 +499,23 @@ function forwardProxyToEnv() {
         try {
             const hosts = JSON.parse(bypassList);
             if (Array.isArray(hosts) && hosts.length > 0) {
-                process.env.NO_PROXY = hosts.join(',');
+                // .proxybypass entries are ECMAScript regex patterns per ADO docs.
+                // Only simple hostname patterns (e.g. artifactory\.corp\.com) are supported —
+                // strip backslash escaping from dots to produce a plain hostname for NO_PROXY.
+                // Entries containing regex special chars like * cannot be reliably converted
+                // and are skipped with a warning.
+                const converted = [];
+                for (const h of hosts) {
+                    if (/[*+?[\]()^${}|\\][^.]/.test(h) || h.includes('*')) {
+                        tl.warning('Skipping Agent.ProxyBypassList entry "' + h + '": regex patterns with wildcards or special characters are not supported for NO_PROXY conversion. Use a plain hostname in your .proxybypass file instead.');
+                        continue;
+                    }
+                    converted.push(h.replace(/\\\./g, '.'));
+                }
+                if (converted.length > 0) {
+                    process.env.NO_PROXY = converted.join(',');
+                    tl.debug('Set NO_PROXY from Agent.ProxyBypassList: ' + process.env.NO_PROXY);
+                }
                 tl.debug('Set NO_PROXY from Agent.ProxyBypassList: ' + process.env.NO_PROXY);
             }
         } catch (e) {

--- a/tests/proxyConfigTest.js
+++ b/tests/proxyConfigTest.js
@@ -226,13 +226,47 @@ runTest('forwardProxyToEnv falls back to original URL when parse fails (no crede
     clearProxyVars();
 });
 
-runTest('forwardProxyToEnv sets NO_PROXY from Agent.ProxyBypassList', () => {
+runTest('forwardProxyToEnv sets NO_PROXY from Agent.ProxyBypassList — plain hostname', () => {
     clearProxyVars();
     tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
-    tl.setVariable('Agent.ProxyBypassList', '["localhost","*.internal.corp"]');
+    tl.setVariable('Agent.ProxyBypassList', '["localhost"]');
     jfrogUtils.forwardProxyToEnv();
-    assert.strictEqual(process.env.HTTP_PROXY, 'http://myproxy:8080');
-    assert.strictEqual(process.env.NO_PROXY, 'localhost,*.internal.corp');
+    assert.strictEqual(process.env.NO_PROXY, 'localhost');
+    clearProxyVars();
+});
+
+runTest('forwardProxyToEnv converts ECMAScript escaped dots to plain hostnames for NO_PROXY', () => {
+    clearProxyVars();
+    // Standard .proxybypass format: dots are escaped as \. (ECMAScript regex)
+    // Agent stores as JSON: "artifactory\\.ctz\\.corp\\.com"
+    // After JSON.parse: "artifactory\.ctz\.corp\.com"
+    // Our fix strips \. → . to produce a valid NO_PROXY hostname
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    tl.setVariable('Agent.ProxyBypassList', '["artifactory\\\\.ctz\\\\.corp\\\\.com"]');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.NO_PROXY, 'artifactory.ctz.corp.com');
+    clearProxyVars();
+});
+
+
+runTest('forwardProxyToEnv skips wildcard entries and warns — simple entries still converted', () => {
+    clearProxyVars();
+    // .*\.corp\.com is a valid ECMAScript regex but cannot be converted to NO_PROXY
+    // artifactory\.corp\.com is a simple hostname pattern — should be converted
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    tl.setVariable('Agent.ProxyBypassList', '[".*\\\\.corp\\\\.com","artifactory\\\\.corp\\\\.com"]');
+    jfrogUtils.forwardProxyToEnv();
+    // Wildcard entry skipped, simple entry converted correctly
+    assert.strictEqual(process.env.NO_PROXY, 'artifactory.corp.com');
+    clearProxyVars();
+});
+
+runTest('forwardProxyToEnv does not set NO_PROXY when all entries are wildcard patterns', () => {
+    clearProxyVars();
+    tl.setVariable('Agent.ProxyUrl', 'http://myproxy:8080');
+    tl.setVariable('Agent.ProxyBypassList', '[".*\\\\.corp\\\\.com"]');
+    jfrogUtils.forwardProxyToEnv();
+    assert.strictEqual(process.env.NO_PROXY, undefined);
     clearProxyVars();
 });
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
## Summary

  - Removed automatic forwarding of `Agent.ProxyUrl` to `HTTP_PROXY`/`HTTPS_PROXY` for JFrog CLI, restoring the backward-compatible behavior from v1.12.7. This was
   a breaking change introduced in v1.12.8 that caused internal Artifactory instances to be unexpectedly routed through the corporate proxy.
  - Fixed ECMAScript regex pattern conversion in `forwardProxyToEnv()` — `.proxybypass` entries (e.g. `artifactory\.corp\.com`) are now correctly converted to
  plain hostnames (e.g. `artifactory.corp.com`) when setting `NO_PROXY`, as per the ADO agent proxy documentation.
  -- `.*\.corp\.com` → skipped with warning: "Skipping entry ... regex patterns with wildcards are not supported for NO_PROXY conversion. Use a plain hostname
  instead.