### PR TITLE
Fix OIDC CLI version check using semver instead of string comparison

### DIFF
--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -617,10 +617,7 @@ async function fetchAzureOidcToken(serviceConnectionID) {
 async function exchangeOidcTokenAndSetStepVariables(service, serviceUrl, oidcProviderName, cliPath, buildDir) {
     // First validate supported CLI version
     let cliVersion = getCliVersion(cliPath);
-    if (semver.lt(cliVersion, '2.75.0')) {
-        throw new Error('CLI version too low');
-    }
-    if (cliVersion < minSupportedOidcCliVersion) {
+    if (semver.lt(cliVersion, minSupportedOidcCliVersion)) {
         throw new Error(
             `The CLI version ${cliVersion} is not supported for OIDC token exchange. Minimum required version is ${minSupportedOidcCliVersion}.`,
         );

--- a/tests/utilsTests.ts
+++ b/tests/utilsTests.ts
@@ -1,5 +1,6 @@
 /// <reference types="mocha" />
 import * as assert from 'assert';
+import * as semver from 'semver';
 
 // Use require to get the actual module with latest exports
 import * as jfrogUtils from '@jfrog/tasks-utils';
@@ -295,6 +296,28 @@ describe('Utils Unit Tests', (): void => {
 
         it('should throw when response body is not valid JSON (simulated)', async (): Promise<void> => {
             await assert.rejects((): Promise<string> => simulateOidcTokenResponse(200, 'not-json'), SyntaxError);
+        });
+    });
+
+    describe('OIDC minimum CLI version check', (): void => {
+        // Regression test: string comparison ('2.101.0' < '2.75.0') incorrectly returns true
+        // because '1' < '7' lexicographically. semver.lt must be used instead.
+        const minOidcVersion: string = '2.75.0';
+
+        it('should recognise 2.101.0 as above minimum (3-digit minor regression)', (): void => {
+            assert.strictEqual(semver.lt('2.101.0', minOidcVersion), false);
+        });
+
+        it('should recognise 2.100.0 as above minimum', (): void => {
+            assert.strictEqual(semver.lt('2.100.0', minOidcVersion), false);
+        });
+
+        it('should recognise 2.75.0 as meeting minimum exactly', (): void => {
+            assert.strictEqual(semver.lt('2.75.0', minOidcVersion), false);
+        });
+
+        it('should recognise 2.74.9 as below minimum', (): void => {
+            assert.strictEqual(semver.lt('2.74.9', minOidcVersion), true);
         });
     });
 });


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

## Summary
- OIDC token exchange was incorrectly rejecting CLI versions with a 3-digit minor (e.g. `2.101.0`) because the version check used a plain string comparison (`cliVersion < minSupportedOidcCliVersion`), which evaluates `'2.101.0' < '2.75.0'` as `true` lexicographically (`'1' < '7'`).
- Fixed by replacing the string comparison with `semver.lt`, which was already imported and used correctly in the same function.
- Added regression tests covering `2.100.0`, `2.101.0`, `2.75.0` (exact minimum), and `2.74.9` (below minimum).