### PR TITLE
feat(e2e): add automated end-to-end testing infrastructure for the ex…

### DIFF
--- a/.github/workflows/e2e-plugin-tests.yml
+++ b/.github/workflows/e2e-plugin-tests.yml
@@ -1,0 +1,158 @@
+# End-to-end plugin tests — the automated equivalent of the manual sanity
+# process described in the release guide.
+#
+# FLOW
+# ----
+#   1. build-and-install  : Build .vsix from the PR branch, publish it to a
+#                           private ADO publisher, install it in the dev org.
+#   2. sanity-tests       : Trigger the ADO sanity pipeline
+#                           (.pipelines/ado-sanity-pipeline.yml) in parallel.
+#                           Covers: ToolsInstaller, GenericArtifacts, Maven,
+#                           PublishBuildInfo, DiscardBuilds.
+#   3. oidc-tests         : Trigger the OIDC test pipeline in parallel.
+#                           Covers all task types with OIDC + non-OIDC auth.
+#
+# REQUIRED GITHUB SECRETS
+# -----------------------
+#   ADO_E2E_ORG              ADO organisation name (publisher host + test host)
+#   ADO_E2E_PAT              PAT with scopes:
+#                              • Marketplace: Publish + Manage
+#                              • Build: Read + Execute
+#                              • Project and Team: Read
+#   ADO_SANITY_PROJECT       ADO project containing the sanity pipeline
+#   ADO_SANITY_PIPELINE_ID   Definition ID of .pipelines/ado-sanity-pipeline.yml
+#   ADO_OIDC_PROJECT         ADO project containing the OIDC test pipeline
+#   ADO_OIDC_PIPELINE_ID     Definition ID of the OIDC test pipeline
+#
+# ONE-TIME SETUP (per dev org — done once, not per PR)
+# ----------------------------------------------------
+#   1. Create a Marketplace publisher: https://aka.ms/vsm-create-publisher
+#      Name it exactly "<ADO_E2E_ORG>-private"
+#   2. Import .pipelines/ado-sanity-pipeline.yml into ADO as a pipeline.
+#      Note the definition ID → set as ADO_SANITY_PIPELINE_ID secret.
+#   3. Create the OIDC test pipeline (see docs/oidc-test-setup.md).
+#      Note the definition ID → set as ADO_OIDC_PIPELINE_ID secret.
+
+name: E2E Plugin Tests
+
+on:
+  # Run automatically when a PR receives the "safe to test" label.
+  pull_request_target:
+    types: [labeled]
+  # Allow manual triggering from the Actions UI for debugging.
+  workflow_dispatch:
+    inputs:
+      timeout_minutes:
+        description: 'Max minutes to wait for each ADO pipeline (default: 60)'
+        required: false
+        default: '60'
+      skip_oidc:
+        description: 'Skip OIDC tests (true/false)'
+        required: false
+        default: 'false'
+
+# Only one E2E run at a time — prevents two PRs racing to install into
+# the same dev org simultaneously.
+concurrency:
+  group: e2e-plugin-tests
+  cancel-in-progress: false
+
+# ======================================================================
+# JOB 1 — Build the extension and install it into the dev ADO org.
+# All subsequent jobs depend on this one completing successfully.
+# ======================================================================
+jobs:
+  build-and-install:
+    name: '1. Build → Publish → Install'
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install and build extension
+        # build.js installs all task node_modules and compiles TypeScript.
+        run: npm install --no-fund
+
+      - name: Publish private extension and install into dev org
+        # Sets a traceable version: 0.<PR_NUMBER>.<RUN_NUMBER>
+        # so the installed .vsix can be correlated to this exact PR run.
+        env:
+          ADO_ARTIFACTORY_DEVELOPER: ${{ secrets.ADO_E2E_ORG }}
+          ADO_ARTIFACTORY_API_KEY: ${{ secrets.ADO_E2E_PAT }}
+          EXTENSION_VERSION_OVERRIDE: "0.${{ github.event.pull_request.number || 0 }}.${{ github.run_number }}"
+        run: bash buildScripts/publish-private.sh
+
+      - name: Print installed version for traceability
+        run: |
+          echo "Extension version 0.${{ github.event.pull_request.number || 0 }}.${{ github.run_number }} installed into org ${{ secrets.ADO_E2E_ORG }}"
+          echo "PR     : #${{ github.event.pull_request.number }}"
+          echo "Commit : ${{ github.event.pull_request.head.sha || github.sha }}"
+
+  # ======================================================================
+  # JOB 2 — Sanity tests (non-OIDC, mirrors manual release sanity check).
+  # Runs in parallel with Job 3 after Job 1 completes.
+  # ======================================================================
+  sanity-tests:
+    name: '2. Sanity Tests (Maven + BuildInfo)'
+    needs: build-and-install
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout (for trigger script)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Trigger ADO sanity pipeline and wait for result
+        # The sanity pipeline (.pipelines/ado-sanity-pipeline.yml) tests:
+        #   JFrogToolsInstaller, GenericArtifacts (upload+download),
+        #   JFrogMaven (resolve+deploy), PublishBuildInfo, DiscardBuilds.
+        env:
+          ADO_ORG: ${{ secrets.ADO_E2E_ORG }}
+          ADO_PROJECT: ${{ secrets.ADO_SANITY_PROJECT }}
+          ADO_PIPELINE_ID: ${{ secrets.ADO_SANITY_PIPELINE_ID }}
+          ADO_PAT: ${{ secrets.ADO_E2E_PAT }}
+          GH_PR_NUMBER: ${{ github.event.pull_request.number || 0 }}
+          GH_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          TIMEOUT_MINUTES: ${{ github.event.inputs.timeout_minutes || '60' }}
+        run: bash buildScripts/trigger-ado-pipeline.sh
+
+  # ======================================================================
+  # JOB 3 — OIDC tests (all task types with OIDC + non-OIDC regression).
+  # Runs in parallel with Job 2 after Job 1 completes.
+  # ======================================================================
+  oidc-tests:
+    name: '3. OIDC Tests (all task types)'
+    needs: build-and-install
+    if: ${{ github.event.inputs.skip_oidc != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout (for trigger script)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Trigger ADO OIDC test pipeline and wait for result
+        # The OIDC pipeline covers:
+        #   A1-A12: all task types with OIDC service connections
+        #   D1-D5:  non-OIDC regression guard (API token + basic auth)
+        #   I1:     multi-task chain (GenericArtifacts + PublishBuildInfo + Audit)
+        env:
+          ADO_ORG: ${{ secrets.ADO_E2E_ORG }}
+          ADO_PROJECT: ${{ secrets.ADO_OIDC_PROJECT }}
+          ADO_PIPELINE_ID: ${{ secrets.ADO_OIDC_PIPELINE_ID }}
+          ADO_PAT: ${{ secrets.ADO_E2E_PAT }}
+          GH_PR_NUMBER: ${{ github.event.pull_request.number || 0 }}
+          GH_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          TIMEOUT_MINUTES: ${{ github.event.inputs.timeout_minutes || '60' }}
+        run: bash buildScripts/trigger-ado-pipeline.sh

--- a/.pipelines/ado-oidc-regression-pipeline.yml
+++ b/.pipelines/ado-oidc-regression-pipeline.yml
@@ -1,0 +1,688 @@
+# OIDC regression pipeline for the JFrog Azure DevOps Extension.
+#
+# PURPOSE
+# -------
+# This pipeline is the automated equivalent of the manual OIDC regression suite
+# created during PR #608.  It exercises every code path through
+# `configureSpecificCliServer()` in `jfrog-tasks-utils/utils.js` against both
+# OIDC and non-OIDC service connections.
+#
+# It is triggered by the GitHub Actions workflow
+# (.github/workflows/e2e-plugin-tests.yml, Job 3 "oidc-tests") after a fresh
+# build of the extension is published and installed into the dev ADO org.
+#
+# WHAT IT TESTS
+# -------------
+# 9 parallel stages cover all 5 `configure*Server()` paths:
+#
+#   S1  Platform OIDC                 -> configureJfrogCliServer
+#   S2  Artifactory V2 OIDC (9 jobs)  -> configureArtifactoryCliServer +
+#                                         configureDefaultArtifactoryServer
+#   S3  Xray OIDC                     -> configureDefaultXrayServer
+#   S4  Distribution OIDC             -> configureDefaultDistributionServer
+#   S5  Maven OIDC                    -> configureArtifactoryCliServer (Maven)
+#   S6  Gradle OIDC                   -> configureArtifactoryCliServer (Gradle)
+#   S7  Go OIDC                       -> createBuildToolConfigFile path
+#   S8  Non-OIDC regression guard     -> token + basic auth (must still pass)
+#   S9  Multi-task OIDC chain         -> realistic multi-step user pipeline
+#
+# ONE-TIME ADO SETUP (per dev org)
+# --------------------------------
+# Service connections required (override defaults via pipeline parameters):
+#
+#   sc-platform-oidc       JFrog Platform        OIDC provider
+#   sc-artifactory-oidc    JFrog Artifactory V2  OIDC provider
+#   sc-artifactory-token   JFrog Artifactory V2  API token        (Non-OIDC guard)
+#   sc-artifactory-basic   JFrog Artifactory V2  Username + Pwd   (Non-OIDC guard)
+#   sc-xray-oidc           JFrog Xray            OIDC provider
+#   sc-xray-basic          JFrog Xray            Username + Pwd   (Non-OIDC guard)
+#   sc-distribution-oidc   JFrog Distribution    OIDC provider
+#   sc-distribution-basic  JFrog Distribution    Username + Pwd   (Non-OIDC guard)
+#
+# Artifactory repositories required:
+#   ecomatrix-generic-local, ecomatrix-maven-local, ecomatrix-maven-remote,
+#   ecomatrix-npm-remote, ecomatrix-pypi-remote, ecomatrix-go-remote,
+#   ecomatrix-gradle-local, ecomatrix-gradle-remote, jfrog-cli-remote.
+#
+# Import this YAML into ADO and store the definition ID in GitHub secret
+# ADO_OIDC_PIPELINE_ID.
+#
+# TRACEABILITY
+# ------------
+# GitHub Actions passes GH_PR_NUMBER and GH_COMMIT_SHA as pipeline variables
+# so every ADO run can be correlated back to the exact PR and commit.
+
+trigger: none   # Only triggered via REST API from GitHub Actions.
+
+parameters:
+  - name: scPlatformOidc
+    displayName: 'Platform OIDC service connection'
+    type: string
+    default: 'sc-platform-oidc'
+  - name: scArtifactoryOidc
+    displayName: 'Artifactory OIDC service connection'
+    type: string
+    default: 'sc-artifactory-oidc'
+  - name: scArtifactoryToken
+    displayName: 'Artifactory token service connection (non-OIDC guard)'
+    type: string
+    default: 'sc-artifactory-token'
+  - name: scArtifactoryBasic
+    displayName: 'Artifactory basic-auth service connection (non-OIDC guard)'
+    type: string
+    default: 'sc-artifactory-basic'
+  - name: scXrayOidc
+    displayName: 'Xray OIDC service connection'
+    type: string
+    default: 'sc-xray-oidc'
+  - name: scXrayBasic
+    displayName: 'Xray basic-auth service connection (non-OIDC guard)'
+    type: string
+    default: 'sc-xray-basic'
+  - name: scDistributionOidc
+    displayName: 'Distribution OIDC service connection'
+    type: string
+    default: 'sc-distribution-oidc'
+  - name: scDistributionBasic
+    displayName: 'Distribution basic-auth service connection (non-OIDC guard)'
+    type: string
+    default: 'sc-distribution-basic'
+
+variables:
+  GH_PR_NUMBER:  $[coalesce(variables['GH_PR_NUMBER'],  '0')]
+  GH_COMMIT_SHA: $[coalesce(variables['GH_COMMIT_SHA'], 'unknown')]
+  BUILD_NAME:    'oidc-pr$(GH_PR_NUMBER)-$(Build.BuildId)'
+  BUILD_NUMBER:  '$(Build.BuildNumber)'
+
+# ======================================================================
+# STAGE S1 — Platform OIDC (baseline: if this fails, ADO infra is broken)
+# Tests configureJfrogCliServer() via JFrogCliV2.
+# ======================================================================
+stages:
+  - stage: S1_PlatformOidc
+    displayName: 'S1 Platform OIDC (baseline)'
+    dependsOn: []
+    jobs:
+      - job: S1_CliV2
+        displayName: 'CliV2 ping (Platform OIDC)'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - script: echo "##[section]OIDC PR #$(GH_PR_NUMBER) commit $(GH_COMMIT_SHA)"
+            displayName: 'Print traceability'
+          - task: JFrogCliV2@1
+            displayName: 'jf rt ping via Platform OIDC'
+            inputs:
+              jfrogPlatformConnection: ${{ parameters.scPlatformOidc }}
+              command: |
+                jf --version
+                jf rt ping
+
+  # ====================================================================
+  # STAGE S2 — Artifactory V2 OIDC (core OIDC stage, 9 parallel jobs)
+  # Covers configureArtifactoryCliServer + configureDefaultArtifactoryServer.
+  # ====================================================================
+  - stage: S2_ArtifactoryOidc
+    displayName: 'S2 Artifactory V2 OIDC (core)'
+    dependsOn: []
+    jobs:
+
+      # --- A2: Generic upload + download (in-job dependency) ----------
+      - job: S2_A2_GenericUpload
+        displayName: 'A2 Generic Upload (Artifactory OIDC)'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - script: |
+              echo "oidc test file PR=$(GH_PR_NUMBER) sha=$(GH_COMMIT_SHA)" > /tmp/oidc-a2.txt
+            displayName: 'Create test file'
+          - task: JFrogGenericArtifacts@1
+            displayName: 'Upload via OIDC'
+            inputs:
+              command: Upload
+              connection: ${{ parameters.scArtifactoryOidc }}
+              specSource: taskConfiguration
+              fileSpec: |
+                {
+                  "files": [{
+                    "pattern": "/tmp/oidc-a2.txt",
+                    "target":  "ecomatrix-generic-local/oidc-pr$(GH_PR_NUMBER)/"
+                  }]
+                }
+              collectBuildInfo: true
+              buildName:   '$(BUILD_NAME)'
+              buildNumber: '$(BUILD_NUMBER)'
+              includeEnvVars: false
+
+      - job: S2_A2_GenericDownload
+        displayName: 'A2 Generic Download (Artifactory OIDC)'
+        dependsOn: S2_A2_GenericUpload
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - task: JFrogGenericArtifacts@1
+            displayName: 'Download via OIDC'
+            inputs:
+              command: Download
+              connection: ${{ parameters.scArtifactoryOidc }}
+              specSource: taskConfiguration
+              fileSpec: |
+                {
+                  "files": [{
+                    "pattern": "ecomatrix-generic-local/oidc-pr$(GH_PR_NUMBER)/oidc-a2.txt",
+                    "target":  "/tmp/oidc-downloaded/"
+                  }]
+                }
+          - script: |
+              if [ -f "/tmp/oidc-downloaded/oidc-pr$(GH_PR_NUMBER)/oidc-a2.txt" ]; then
+                echo "Round-trip OK"
+              else
+                echo "Round-trip FAILED — file not downloaded"; exit 1
+              fi
+            displayName: 'Verify round-trip'
+
+      # --- A4: PublishBuildInfo (depends on A2 upload) ----------------
+      - job: S2_A4_PublishBuildInfo
+        displayName: 'A4 PublishBuildInfo (Artifactory OIDC)'
+        dependsOn: S2_A2_GenericUpload
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - task: JFrogPublishBuildInfo@1
+            displayName: 'Publish build info via OIDC'
+            inputs:
+              artifactoryConnection: ${{ parameters.scArtifactoryOidc }}
+              buildName:   '$(BUILD_NAME)'
+              buildNumber: '$(BUILD_NUMBER)'
+              excludeEnvVars: '*password*;*psw*;*secret*;*key*;*token*;*auth*'
+
+      # --- A_Promote: BuildPromotion dry run (depends on A4) ----------
+      - job: S2_A_Promote
+        displayName: 'A_Promote BuildPromotion dry-run (OIDC)'
+        dependsOn: S2_A4_PublishBuildInfo
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - task: JFrogBuildPromotion@1
+            displayName: 'Promote build (dry run)'
+            inputs:
+              artifactoryConnection: ${{ parameters.scArtifactoryOidc }}
+              buildName:   '$(BUILD_NAME)'
+              buildNumber: '$(BUILD_NUMBER)'
+              targetRepo:  'ecomatrix-generic-local'
+              status:      'staged'
+              comment:     'OIDC dry-run promotion (PR #$(GH_PR_NUMBER))'
+              dryRun: true
+
+      # --- A_Discard: DiscardBuilds (cleanup) -------------------------
+      - job: S2_A_Discard
+        displayName: 'A_Discard DiscardBuilds (OIDC)'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - task: JFrogDiscardBuilds@1
+            displayName: 'Discard old OIDC builds (keep last 5)'
+            inputs:
+              artifactoryConnection: ${{ parameters.scArtifactoryOidc }}
+              buildName: 'oidc-pr$(GH_PR_NUMBER)-*'
+              maxBuilds: 5
+            continueOnError: true
+
+      # --- A_CollectIssues --------------------------------------------
+      - job: S2_A_CollectIssues
+        displayName: 'A_CollectIssues (OIDC)'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - script: |
+              cat > /tmp/issues-config.yaml <<'EOF'
+              issues:
+                trackerName: JIRA
+                regexp: ([A-Z]+-[0-9]+)\s-\s(.+)
+                keyGroupIndex: 1
+                summaryGroupIndex: 2
+                trackerUrl: https://example.atlassian.net
+                aggregate: true
+                aggregationStatus: RELEASED
+              EOF
+            displayName: 'Write issue collection config'
+          - task: JFrogCollectIssues@1
+            displayName: 'Collect issues (OIDC)'
+            inputs:
+              artifactoryConnection: ${{ parameters.scArtifactoryOidc }}
+              configSource: 'file'
+              file: '/tmp/issues-config.yaml'
+              buildName:   '$(BUILD_NAME)'
+              buildNumber: '$(BUILD_NUMBER)'
+            continueOnError: true   # collection may fail without a real Git history
+
+      # --- A_ToolsInstaller_Token: NON-OIDC GUARD ---------------------
+      # Verifies the existing API-token download path still works after
+      # the OIDC fix (regression guard).
+      - job: S2_A_ToolsInstaller_Token
+        displayName: 'A_ToolsInstaller via TOKEN [GUARD non-OIDC]'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - task: JFrogToolsInstaller@1
+            displayName: 'Install JFrog CLI via API token (non-OIDC)'
+            inputs:
+              artifactoryConnection: ${{ parameters.scArtifactoryToken }}
+              cliInstallationRepo: 'jfrog-cli-remote'
+              installJFrogCli: true
+          - script: jf --version
+            displayName: 'Verify CLI installed'
+
+      # --- A_ToolsInstaller_Extractors_OIDC ---------------------------
+      - job: S2_A_ToolsInstaller_Extractors_OIDC
+        displayName: 'A_ToolsInstaller extractors via OIDC'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - task: JFrogToolsInstaller@1
+            displayName: 'Install CLI + Maven/Gradle extractors via OIDC'
+            inputs:
+              artifactoryConnection: ${{ parameters.scArtifactoryOidc }}
+              cliInstallationRepo: 'jfrog-cli-remote'
+              installJFrogCli: true
+              installExtractors: true
+              extractorsInstallationRepo: 'jfrog-cli-remote'
+
+      # --- A_Npm: npm install via OIDC --------------------------------
+      - job: S2_A_Npm
+        displayName: 'A_Npm install via OIDC'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - task: NodeTool@0
+            displayName: 'Install Node.js 20'
+            inputs: { versionSpec: '20.x' }
+          - script: |
+              mkdir -p /tmp/npm-oidc && cd /tmp/npm-oidc
+              cat > package.json <<'EOF'
+              {
+                "name": "oidc-npm-test",
+                "version": "1.0.0",
+                "dependencies": { "lodash": "4.17.21" }
+              }
+              EOF
+            displayName: 'Create test package.json'
+          - task: JFrogNpm@1
+            displayName: 'npm install via OIDC'
+            inputs:
+              command: 'install'
+              artifactoryConnection: ${{ parameters.scArtifactoryOidc }}
+              sourceRepo: 'ecomatrix-npm-remote'
+              workingFolder: '/tmp/npm-oidc'
+              collectBuildInfo: true
+              buildName:   '$(BUILD_NAME)'
+              buildNumber: '$(BUILD_NUMBER)'
+
+      # --- A_Pip: pip install via OIDC --------------------------------
+      - job: S2_A_Pip
+        displayName: 'A_Pip install via OIDC'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - task: UsePythonVersion@0
+            displayName: 'Install Python 3.11'
+            inputs: { versionSpec: '3.11' }
+          - task: JFrogPip@1
+            displayName: 'pip install via OIDC'
+            inputs:
+              artifactoryConnection: ${{ parameters.scArtifactoryOidc }}
+              command: 'install'
+              arguments: 'requests==2.31.0'
+              targetResolveRepo: 'ecomatrix-pypi-remote'
+              collectBuildInfo: true
+              buildName:   '$(BUILD_NAME)'
+              buildNumber: '$(BUILD_NUMBER)'
+
+  # ====================================================================
+  # STAGE S3 — Xray OIDC
+  # Tests configureDefaultXrayServer() via Audit + Docker Scan.
+  # ====================================================================
+  - stage: S3_XrayOidc
+    displayName: 'S3 Xray OIDC'
+    dependsOn: []
+    jobs:
+      - job: S3_A6_Audit
+        displayName: 'A6 JFrogAudit (Xray OIDC)'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - script: |
+              mkdir -p /tmp/xray-audit && cd /tmp/xray-audit
+              cat > package.json <<'EOF'
+              { "name": "audit-test", "version": "1.0.0", "dependencies": { "lodash": "4.17.20" } }
+              EOF
+            displayName: 'Create project for audit'
+          - task: JFrogAudit@1
+            displayName: 'Audit via Xray OIDC'
+            inputs:
+              xrayConnection: ${{ parameters.scXrayOidc }}
+              workingDirectory: '/tmp/xray-audit'
+              watchesSource: 'none'
+              allowFailBuild: false
+            continueOnError: true   # audit may legitimately surface findings
+
+      - job: S3_A7_DockerScan
+        displayName: 'A7 JFrogDocker Scan (Xray OIDC)'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - task: JFrogDocker@1
+            displayName: 'Docker scan via Xray OIDC'
+            inputs:
+              command: 'scan'
+              xrayConnection: ${{ parameters.scXrayOidc }}
+              imageName: 'alpine:3.18'
+              watchesSource: 'none'
+              allowFailBuild: false
+            continueOnError: true
+
+  # ====================================================================
+  # STAGE S4 — Distribution OIDC
+  # Tests configureDefaultDistributionServer() (dry run).
+  # ====================================================================
+  - stage: S4_DistributionOidc
+    displayName: 'S4 Distribution OIDC'
+    dependsOn: []
+    jobs:
+      - job: S4_Distribution
+        displayName: 'JFrogDistribution dry-run (OIDC)'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - task: JFrogDistribution@1
+            displayName: 'Create release bundle (dry run)'
+            inputs:
+              distributionConnection: ${{ parameters.scDistributionOidc }}
+              command: 'Create Release Bundle'
+              rbName:    'oidc-rb-pr$(GH_PR_NUMBER)'
+              rbVersion: '0.0.$(Build.BuildId)'
+              specSource: 'taskConfiguration'
+              fileSpec: |
+                {
+                  "files": [{
+                    "pattern": "ecomatrix-generic-local/oidc-pr$(GH_PR_NUMBER)/*"
+                  }]
+                }
+              dryRun: true
+            continueOnError: true   # Distribution may not be enabled in all dev envs
+
+  # ====================================================================
+  # STAGE S5 — Maven OIDC
+  # Tests configureArtifactoryCliServer() called from JFrogMaven.
+  # ====================================================================
+  - stage: S5_MavenOidc
+    displayName: 'S5 Maven OIDC'
+    dependsOn: []
+    jobs:
+      - job: S5_Maven
+        displayName: 'JFrogMaven (Artifactory OIDC)'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - task: JavaToolInstaller@0
+            displayName: 'Install Java 11'
+            inputs:
+              versionSpec: '11'
+              jdkArchitectureOption: 'x64'
+              jdkSourceOption: 'PreInstalled'
+          - script: |
+              mkdir -p /tmp/maven-oidc && cd /tmp/maven-oidc
+              cat > pom.xml <<'EOF'
+              <project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.jfrog.oidc</groupId>
+                <artifactId>oidc-test</artifactId>
+                <version>1.0.0</version>
+                <packaging>jar</packaging>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                    <version>3.12.0</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              EOF
+            displayName: 'Create inline pom.xml'
+          - task: JFrogMaven@1
+            displayName: 'Maven resolve + deploy via OIDC'
+            inputs:
+              mavenPOMFile: '/tmp/maven-oidc/pom.xml'
+              goals: 'install -DskipTests'
+              artifactoryResolverService: ${{ parameters.scArtifactoryOidc }}
+              targetResolveReleaseRepo:   'ecomatrix-maven-remote'
+              targetResolveSnapshotRepo:  'ecomatrix-maven-remote'
+              artifactoryDeployService:   ${{ parameters.scArtifactoryOidc }}
+              targetDeployReleaseRepo:    'ecomatrix-maven-local'
+              targetDeploySnapshotRepo:   'ecomatrix-maven-local'
+              collectBuildInfo: true
+              buildName:   '$(BUILD_NAME)'
+              buildNumber: '$(BUILD_NUMBER)'
+              includeEnvVars: false
+
+  # ====================================================================
+  # STAGE S6 — Gradle OIDC
+  # Tests configureArtifactoryCliServer() called from JFrogGradle.
+  # ====================================================================
+  - stage: S6_GradleOidc
+    displayName: 'S6 Gradle OIDC'
+    dependsOn: []
+    jobs:
+      - job: S6_Gradle
+        displayName: 'JFrogGradle (Artifactory OIDC)'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - task: JavaToolInstaller@0
+            displayName: 'Install Java 11'
+            inputs:
+              versionSpec: '11'
+              jdkArchitectureOption: 'x64'
+              jdkSourceOption: 'PreInstalled'
+          - script: |
+              mkdir -p /tmp/gradle-oidc && cd /tmp/gradle-oidc
+              cat > settings.gradle <<'EOF'
+              rootProject.name = 'oidc-gradle-test'
+              EOF
+              cat > build.gradle <<'EOF'
+              plugins { id 'java' }
+              group   = 'org.jfrog.oidc'
+              version = '1.0.0'
+              repositories { mavenCentral() }
+              dependencies { implementation 'org.apache.commons:commons-lang3:3.12.0' }
+              EOF
+            displayName: 'Create inline Gradle project'
+          - task: JFrogGradle@1
+            displayName: 'Gradle build via OIDC'
+            inputs:
+              gradleBuildFile: '/tmp/gradle-oidc/build.gradle'
+              tasks: 'build'
+              artifactoryResolverService: ${{ parameters.scArtifactoryOidc }}
+              targetResolveRepo:          'ecomatrix-gradle-remote'
+              artifactoryDeployService:   ${{ parameters.scArtifactoryOidc }}
+              targetDeployRepo:           'ecomatrix-gradle-local'
+              collectBuildInfo: true
+              buildName:   '$(BUILD_NAME)'
+              buildNumber: '$(BUILD_NUMBER)'
+              includeEnvVars: false
+
+  # ====================================================================
+  # STAGE S7 — Go OIDC
+  # Tests createBuildToolConfigFile -> configureDefaultArtifactoryServer
+  # via JFrogGo.
+  # ====================================================================
+  - stage: S7_GoOidc
+    displayName: 'S7 Go OIDC'
+    dependsOn: []
+    jobs:
+      - job: S7_Go
+        displayName: 'JFrogGo (Artifactory OIDC)'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - task: GoTool@0
+            displayName: 'Install Go 1.21'
+            inputs: { version: '1.21' }
+          - script: |
+              mkdir -p /tmp/go-oidc && cd /tmp/go-oidc
+              cat > go.mod <<'EOF'
+              module oidc-go-test
+
+              go 1.21
+
+              require github.com/google/uuid v1.4.0
+              EOF
+              cat > main.go <<'EOF'
+              package main
+
+              import (
+                  "fmt"
+
+                  "github.com/google/uuid"
+              )
+
+              func main() { fmt.Println(uuid.New().String()) }
+              EOF
+            displayName: 'Create inline Go module'
+          - task: JFrogGo@1
+            displayName: 'Go build via OIDC'
+            inputs:
+              command: 'build'
+              artifactoryConnection: ${{ parameters.scArtifactoryOidc }}
+              resolutionRepo: 'ecomatrix-go-remote'
+              workingDirectory: '/tmp/go-oidc'
+              collectBuildInfo: true
+              buildName:   '$(BUILD_NAME)'
+              buildNumber: '$(BUILD_NUMBER)'
+
+  # ====================================================================
+  # STAGE S8 — Non-OIDC regression guard
+  # Verifies token + basic auth code paths still work AFTER the OIDC fix.
+  # These four jobs MUST pass with both the unfixed and fixed plugin.
+  # ====================================================================
+  - stage: S8_NonOidcGuard
+    displayName: 'S8 Non-OIDC regression guard'
+    dependsOn: []
+    jobs:
+      - job: S8_D1_Generic_Token
+        displayName: 'D1 Generic via TOKEN [GUARD]'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - script: echo "guard token PR=$(GH_PR_NUMBER)" > /tmp/guard-token.txt
+            displayName: 'Create test file'
+          - task: JFrogGenericArtifacts@1
+            displayName: 'Upload via API token'
+            inputs:
+              command: Upload
+              connection: ${{ parameters.scArtifactoryToken }}
+              specSource: taskConfiguration
+              fileSpec: |
+                {
+                  "files": [{
+                    "pattern": "/tmp/guard-token.txt",
+                    "target":  "ecomatrix-generic-local/guard-token-pr$(GH_PR_NUMBER)/"
+                  }]
+                }
+
+      - job: S8_D2_Generic_Basic
+        displayName: 'D2 Generic via BASIC AUTH [GUARD]'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - script: echo "guard basic PR=$(GH_PR_NUMBER)" > /tmp/guard-basic.txt
+            displayName: 'Create test file'
+          - task: JFrogGenericArtifacts@1
+            displayName: 'Upload via basic auth'
+            inputs:
+              command: Upload
+              connection: ${{ parameters.scArtifactoryBasic }}
+              specSource: taskConfiguration
+              fileSpec: |
+                {
+                  "files": [{
+                    "pattern": "/tmp/guard-basic.txt",
+                    "target":  "ecomatrix-generic-local/guard-basic-pr$(GH_PR_NUMBER)/"
+                  }]
+                }
+
+      - job: S8_D3_Audit_Basic
+        displayName: 'D3 Audit via XRAY BASIC AUTH [GUARD]'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - script: |
+              mkdir -p /tmp/d3-audit && cd /tmp/d3-audit
+              echo '{ "name":"d3","version":"1.0.0","dependencies":{"lodash":"4.17.20"} }' > package.json
+            displayName: 'Create project'
+          - task: JFrogAudit@1
+            displayName: 'Audit via Xray basic auth'
+            inputs:
+              xrayConnection: ${{ parameters.scXrayBasic }}
+              workingDirectory: '/tmp/d3-audit'
+              watchesSource: 'none'
+              allowFailBuild: false
+            continueOnError: true
+
+      - job: S8_D4_Distribution_Basic
+        displayName: 'D4 Distribution via BASIC AUTH dry-run [GUARD]'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - task: JFrogDistribution@1
+            displayName: 'Create release bundle (dry run)'
+            inputs:
+              distributionConnection: ${{ parameters.scDistributionBasic }}
+              command: 'Create Release Bundle'
+              rbName:    'guard-rb-pr$(GH_PR_NUMBER)'
+              rbVersion: '0.0.$(Build.BuildId)'
+              specSource: 'taskConfiguration'
+              fileSpec: |
+                {
+                  "files": [{
+                    "pattern": "ecomatrix-generic-local/guard-basic-pr$(GH_PR_NUMBER)/*"
+                  }]
+                }
+              dryRun: true
+            continueOnError: true
+
+  # ====================================================================
+  # STAGE S9 — Multi-task OIDC chain (most realistic scenario)
+  # One job, three tasks in sequence, three different OIDC service
+  # connection types.  Verifies tokens are exchanged independently
+  # per task and do not interfere with each other.
+  # ====================================================================
+  - stage: S9_MultiTaskOidcChain
+    displayName: 'S9 Multi-task OIDC chain'
+    dependsOn: []
+    jobs:
+      - job: S9_I1
+        displayName: 'I1 GenericArtifacts -> PublishBuildInfo -> Audit (3 OIDC SCs)'
+        pool: { vmImage: 'ubuntu-22.04' }
+        steps:
+          - script: |
+              echo "i1 chain PR=$(GH_PR_NUMBER) commit=$(GH_COMMIT_SHA)" > /tmp/i1-chain.txt
+              mkdir -p /tmp/i1-audit
+              echo '{ "name":"i1","version":"1.0.0","dependencies":{"lodash":"4.17.20"} }' > /tmp/i1-audit/package.json
+            displayName: 'Prepare test artifacts'
+
+          # Task 1: upload via Artifactory OIDC ----------------------
+          - task: JFrogGenericArtifacts@1
+            displayName: 'Step 1 GenericArtifacts upload (Artifactory OIDC)'
+            inputs:
+              command: Upload
+              connection: ${{ parameters.scArtifactoryOidc }}
+              specSource: taskConfiguration
+              fileSpec: |
+                {
+                  "files": [{
+                    "pattern": "/tmp/i1-chain.txt",
+                    "target":  "ecomatrix-generic-local/i1-pr$(GH_PR_NUMBER)/"
+                  }]
+                }
+              collectBuildInfo: true
+              buildName:   '$(BUILD_NAME)-i1'
+              buildNumber: '$(BUILD_NUMBER)'
+
+          # Task 2: publish build info via Artifactory OIDC ----------
+          - task: JFrogPublishBuildInfo@1
+            displayName: 'Step 2 PublishBuildInfo (Artifactory OIDC)'
+            inputs:
+              artifactoryConnection: ${{ parameters.scArtifactoryOidc }}
+              buildName:   '$(BUILD_NAME)-i1'
+              buildNumber: '$(BUILD_NUMBER)'
+              excludeEnvVars: '*password*;*psw*;*secret*;*key*;*token*;*auth*'
+
+          # Task 3: audit via Xray OIDC (different SC type) ----------
+          - task: JFrogAudit@1
+            displayName: 'Step 3 Audit (Xray OIDC) — different SC type'
+            inputs:
+              xrayConnection: ${{ parameters.scXrayOidc }}
+              workingDirectory: '/tmp/i1-audit'
+              watchesSource: 'none'
+              allowFailBuild: false
+            continueOnError: true

--- a/.pipelines/ado-sanity-pipeline.yml
+++ b/.pipelines/ado-sanity-pipeline.yml
@@ -1,0 +1,207 @@
+# Sanity test pipeline for the JFrog Azure DevOps Extension.
+#
+# PURPOSE
+# -------
+# This pipeline is the automated replacement for the manual sanity test
+# described in the release guide.  It is triggered by the GitHub Actions
+# workflow (.github/workflows/e2e-plugin-tests.yml) after a fresh build of
+# the extension is published and installed into the dev ADO organisation.
+#
+# WHAT IT TESTS
+# -------------
+# The pipeline covers the most-critical non-OIDC task flows so that a basic
+# regression is caught before the developer even opens a PR:
+#
+#   1. JFrogToolsInstaller  - download & cache JFrog CLI
+#   2. JFrogGenericArtifacts (Upload)  - upload a test file (configureArtifactoryCliServer)
+#   3. JFrogGenericArtifacts (Download) - download it back
+#   4. JFrogMaven  - full Maven resolve + deploy (configureArtifactoryCliServer)
+#   5. JFrogPublishBuildInfo  - publish build info  (configureDefaultArtifactoryServer)
+#   6. JFrogDiscardBuilds  - clean up (configureDefaultArtifactoryServer)
+#
+# ONE-TIME ADO SETUP (done once per team dev org)
+# ------------------------------------------------
+#   1. In your ADO organisation, create a "JFrog Platform" service connection.
+#      Name it exactly: jfrog-sanity-connection
+#      Point it to a test/dev JFrog Platform instance.
+#
+#   2. In that Artifactory instance, create these repositories:
+#        Generic (local) : sanity-generic-local
+#        Maven (local)   : sanity-libs-release-local, sanity-libs-snapshot-local
+#        Maven (remote)  : sanity-libs-release   (proxy: https://repo.maven.apache.org/maven2)
+#                          sanity-libs-snapshot  (proxy: https://repo.maven.apache.org/maven2)
+#
+#   3. Create a GitHub service connection named: github-jfrog-public
+#      Set it to read from https://github.com/jfrog/project-examples (public, read-only).
+#
+#   4. Import this YAML file as a pipeline in ADO.
+#      Note the pipeline Definition ID and store it in GitHub secret ADO_SANITY_PIPELINE_ID.
+#
+# TRACEABILITY
+# ------------
+# GitHub Actions passes GH_PR_NUMBER and GH_COMMIT_SHA as pipeline variables
+# so every ADO run can be correlated back to the exact PR and commit.
+
+trigger: none   # Only triggered via REST API from GitHub Actions.
+
+parameters:
+  - name: serviceConnection
+    displayName: 'JFrog Platform Service Connection'
+    type: string
+    default: 'jfrog-sanity-connection'
+
+  - name: githubConnection
+    displayName: 'GitHub Service Connection (public repos)'
+    type: string
+    default: 'github-jfrog-public'
+
+variables:
+  # Passed in by GitHub Actions via the pipeline run API variables field.
+  GH_PR_NUMBER:  $[coalesce(variables['GH_PR_NUMBER'],  '0')]
+  GH_COMMIT_SHA: $[coalesce(variables['GH_COMMIT_SHA'], 'unknown')]
+  BUILD_NAME:    'sanity-pr$(GH_PR_NUMBER)-$(Build.BuildId)'
+  BUILD_NUMBER:  '$(Build.BuildNumber)'
+
+pool:
+  vmImage: 'ubuntu-22.04'
+
+resources:
+  repositories:
+    # Public repo containing the Maven example project.
+    # No credentials needed — it is a public repository.
+    - repository: projectExamples
+      type: github
+      endpoint: ${{ parameters.githubConnection }}
+      name: jfrog/project-examples
+      ref: refs/heads/master
+
+steps:
+  # ------------------------------------------------------------------ #
+  # 0. Identify the build                                               #
+  # ------------------------------------------------------------------ #
+  - script: |
+      echo "##[section]Sanity test triggered by GitHub PR #$(GH_PR_NUMBER) — commit $(GH_COMMIT_SHA)"
+      echo "Build name : $(BUILD_NAME)"
+      echo "Build number: $(BUILD_NUMBER)"
+    displayName: 'Print traceability info'
+
+  # ------------------------------------------------------------------ #
+  # 1. Install JFrog CLI                                                #
+  #    Verifies: JFrogToolsInstaller task works end-to-end.            #
+  # ------------------------------------------------------------------ #
+  - task: JFrogToolsInstaller@1
+    displayName: 'Install JFrog CLI'
+    inputs:
+      artifactoryConnection: ${{ parameters.serviceConnection }}
+      cliInstallationRepo: 'jfrog-cli-remote'
+      # 'LATEST' downloads whichever CLI version is configured as default
+      # in the extension. Override here if you need a specific version.
+      installJFrogCli: true
+
+  # ------------------------------------------------------------------ #
+  # 2-3. Generic upload + download                                      #
+  #      Verifies: configureArtifactoryCliServer (direct) path.        #
+  # ------------------------------------------------------------------ #
+  - checkout: self
+    displayName: 'Checkout extension repo (for test file)'
+
+  - script: echo "sanity test file — PR $(GH_PR_NUMBER) — $(GH_COMMIT_SHA)" > /tmp/sanity.txt
+    displayName: 'Create test file'
+
+  - task: JFrogGenericArtifacts@1
+    displayName: 'Upload test file'
+    inputs:
+      command: Upload
+      connection: ${{ parameters.serviceConnection }}
+      specSource: taskConfiguration
+      fileSpec: |
+        {
+          "files": [{
+            "pattern": "/tmp/sanity.txt",
+            "target":  "sanity-generic-local/sanity-pr$(GH_PR_NUMBER)/"
+          }]
+        }
+      collectBuildInfo: true
+      buildName: '$(BUILD_NAME)'
+      buildNumber: '$(BUILD_NUMBER)'
+      includeEnvVars: false
+
+  - task: JFrogGenericArtifacts@1
+    displayName: 'Download test file back'
+    inputs:
+      command: Download
+      connection: ${{ parameters.serviceConnection }}
+      specSource: taskConfiguration
+      fileSpec: |
+        {
+          "files": [{
+            "pattern": "sanity-generic-local/sanity-pr$(GH_PR_NUMBER)/sanity.txt",
+            "target":  "/tmp/sanity-downloaded/"
+          }]
+        }
+      collectBuildInfo: true
+      buildName: '$(BUILD_NAME)'
+      buildNumber: '$(BUILD_NUMBER)'
+
+  - script: |
+      if diff /tmp/sanity.txt /tmp/sanity-downloaded/sanity-pr$(GH_PR_NUMBER)/sanity.txt; then
+        echo "Upload/download round-trip: PASSED"
+      else
+        echo "Upload/download round-trip: FAILED — files differ"
+        exit 1
+      fi
+    displayName: 'Verify download matches upload'
+
+  # ------------------------------------------------------------------ #
+  # 4. Maven build (resolve + deploy)                                   #
+  #    Verifies: configureArtifactoryCliServer used by Maven task.     #
+  # ------------------------------------------------------------------ #
+  - checkout: projectExamples
+    displayName: 'Checkout project-examples (Maven POM)'
+
+  - task: JavaToolInstaller@0
+    displayName: 'Install Java 11'
+    inputs:
+      versionSpec: '11'
+      jdkArchitectureOption: 'x64'
+      jdkSourceOption: 'PreInstalled'
+
+  - task: JFrogMaven@1
+    displayName: 'Maven: resolve from Artifactory, deploy to Artifactory'
+    inputs:
+      mavenPOMFile: 'project-examples/maven-examples/maven-example/pom.xml'
+      goals: 'install -DskipTests'
+      artifactoryResolverService: ${{ parameters.serviceConnection }}
+      targetResolveReleaseRepo:   'sanity-libs-release'
+      targetResolveSnapshotRepo:  'sanity-libs-snapshot'
+      artifactoryDeployService:   ${{ parameters.serviceConnection }}
+      targetDeployReleaseRepo:    'sanity-libs-release-local'
+      targetDeploySnapshotRepo:   'sanity-libs-snapshot-local'
+      collectBuildInfo: true
+      buildName:   '$(BUILD_NAME)'
+      buildNumber: '$(BUILD_NUMBER)'
+      includeEnvVars: false
+
+  # ------------------------------------------------------------------ #
+  # 5. Publish Build Info                                               #
+  #    Verifies: configureDefaultArtifactoryServer path.               #
+  # ------------------------------------------------------------------ #
+  - task: JFrogPublishBuildInfo@1
+    displayName: 'Publish Build Info'
+    inputs:
+      artifactoryConnection: ${{ parameters.serviceConnection }}
+      buildName:   '$(BUILD_NAME)'
+      buildNumber: '$(BUILD_NUMBER)'
+      excludeEnvVars: '*password*;*psw*;*secret*;*key*;*token*;*auth*'
+
+  # ------------------------------------------------------------------ #
+  # 6. Discard old builds (cleanup)                                     #
+  #    Verifies: JFrogDiscardBuilds task + configureDefaultArtifactoryServer #
+  # ------------------------------------------------------------------ #
+  - task: JFrogDiscardBuilds@1
+    displayName: 'Discard old sanity builds (keep last 5)'
+    inputs:
+      artifactoryConnection: ${{ parameters.serviceConnection }}
+      buildName: 'sanity-pr$(GH_PR_NUMBER)-*'
+      maxBuilds: 5
+    continueOnError: true   # cleanup failure should not fail the sanity run

--- a/buildScripts/publish-private.sh
+++ b/buildScripts/publish-private.sh
@@ -8,6 +8,10 @@ set -eu
 # 1. ADO_ARTIFACTORY_DEVELOPER - Developer ID in Visual Studio (Organization name in Azure DevOps)
 # 2. ADO_ARTIFACTORY_API_KEY - API key in Visual Studio (Personal access tokens under 'Security' menu, configured to 'All accessible organizations' in 'Organization' and 'Full access' in 'Scopes'.)
 # 3. Create publisher at https://aka.ms/vsm-create-publisher. It's Name (and ID) should be the value of '$ADO_ARTIFACTORY_DEVELOPER-private' (other details are not required).
+#
+# Optional:
+# EXTENSION_VERSION_OVERRIDE - If set, uses this semver string instead of a random version.
+#   Useful in CI to produce a traceable version like "0.<PR_NUMBER>.<RUN_NUMBER>".
 
 if [ -z "$ADO_ARTIFACTORY_DEVELOPER" ]; then
     echo "Please set ADO_ARTIFACTORY_DEVELOPER first"
@@ -23,6 +27,15 @@ export PUBLISHER=$ADO_ARTIFACTORY_DEVELOPER-private
 GIT_HEAD=$(git rev-parse --short HEAD)
 export GIT_HEAD
 
+# Use EXTENSION_VERSION_OVERRIDE when set (e.g. from CI: "0.<PR>.<run>"),
+# otherwise fall back to random numbers so manual runs still work without setup.
+if [ -n "${EXTENSION_VERSION_OVERRIDE:-}" ]; then
+    VSIX_VERSION="$EXTENSION_VERSION_OVERRIDE"
+else
+    VSIX_VERSION="$RANDOM.$RANDOM.$RANDOM"
+fi
+export VSIX_VERSION
+
 cp vss-extension.json vss-extension-private.json
 
 npx tfx extension unshare -t "$ADO_ARTIFACTORY_API_KEY" --extension-id jfrog-azure-devops-extension --publisher "$PUBLISHER" --unshare-with "$ADO_ARTIFACTORY_DEVELOPER" 2>/dev/null
@@ -35,7 +48,8 @@ if [ "${vsixSize}" -gt 40 ]; then
     echo "Extension vsix size is greater than 30MB! (${vsixSize}MB) - Hint: Most of the dependencies on package-json are in format of - <^x.y.z>, so maybe one of them got updated, and the node_modules directory became bigger"
     exit 1
 fi
-npx tfx extension publish -t "$ADO_ARTIFACTORY_API_KEY" --publisher "$PUBLISHER" --manifests vss-extension-private.json --override "{\"public\": false, \"version\": \"$RANDOM.$RANDOM.$RANDOM\", \"description\": \"Commit SHA: $GIT_HEAD\"}" --share-with "$ADO_ARTIFACTORY_DEVELOPER"
+echo "Publishing extension version: $VSIX_VERSION (commit: $GIT_HEAD)"
+npx tfx extension publish -t "$ADO_ARTIFACTORY_API_KEY" --publisher "$PUBLISHER" --manifests vss-extension-private.json --override "{\"public\": false, \"version\": \"$VSIX_VERSION\", \"description\": \"Commit SHA: $GIT_HEAD\"}" --share-with "$ADO_ARTIFACTORY_DEVELOPER"
 npx tfx extension install --publisher "$PUBLISHER" --extension-id jfrog-azure-devops-extension --service-url https://"$ADO_ARTIFACTORY_DEVELOPER".visualstudio.com -t "$ADO_ARTIFACTORY_API_KEY"
 
 rm -- *.vsix

--- a/buildScripts/trigger-ado-pipeline.sh
+++ b/buildScripts/trigger-ado-pipeline.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -eu
+
+# Trigger an Azure DevOps pipeline run and wait for it to complete.
+#
+# Required environment variables:
+#   ADO_ORG         - Azure DevOps organization name (e.g. vigneshc0742)
+#   ADO_PROJECT     - Azure DevOps project name     (e.g. ecomatrix-test)
+#   ADO_PIPELINE_ID - Pipeline definition ID         (e.g. 63)
+#   ADO_PAT         - PAT with Build Read+Execute and Project Read scopes
+#
+# Optional environment variables:
+#   GH_PR_NUMBER    - GitHub PR number passed into pipeline as a variable (default: 0)
+#   GH_COMMIT_SHA   - Git commit SHA passed into pipeline as a variable (default: unknown)
+#   TIMEOUT_MINUTES - Max minutes to wait for completion (default: 60)
+
+ADO_ORG="${ADO_ORG:?'ADO_ORG is required'}"
+ADO_PROJECT="${ADO_PROJECT:?'ADO_PROJECT is required'}"
+ADO_PIPELINE_ID="${ADO_PIPELINE_ID:?'ADO_PIPELINE_ID is required'}"
+ADO_PAT="${ADO_PAT:?'ADO_PAT is required'}"
+GH_PR_NUMBER="${GH_PR_NUMBER:-0}"
+GH_COMMIT_SHA="${GH_COMMIT_SHA:-unknown}"
+TIMEOUT_MINUTES="${TIMEOUT_MINUTES:-60}"
+
+API_BASE="https://dev.azure.com/${ADO_ORG}/${ADO_PROJECT}/_apis"
+# ADO REST API uses Basic auth with an empty username and PAT as password.
+AUTH_HEADER="Authorization: Basic $(echo -n ":${ADO_PAT}" | base64 -w0 2>/dev/null || echo -n ":${ADO_PAT}" | base64)"
+
+echo "=============================================="
+echo "  Triggering ADO E2E Pipeline"
+echo "  Org:        ${ADO_ORG}"
+echo "  Project:    ${ADO_PROJECT}"
+echo "  Pipeline:   ${ADO_PIPELINE_ID}"
+echo "  PR:         ${GH_PR_NUMBER}"
+echo "  Commit:     ${GH_COMMIT_SHA}"
+echo "=============================================="
+
+# ------------------------------------------------------------------
+# Trigger the pipeline run
+# ------------------------------------------------------------------
+RUN_RESPONSE=$(curl -sf -X POST \
+    "${API_BASE}/pipelines/${ADO_PIPELINE_ID}/runs?api-version=7.1" \
+    -H "${AUTH_HEADER}" \
+    -H "Content-Type: application/json" \
+    -d "{
+          \"variables\": {
+            \"GH_PR_NUMBER\":   { \"value\": \"${GH_PR_NUMBER}\",  \"isSecret\": false },
+            \"GH_COMMIT_SHA\":  { \"value\": \"${GH_COMMIT_SHA}\", \"isSecret\": false }
+          }
+        }" || echo "CURL_FAILED")
+
+if [ "$RUN_RESPONSE" = "CURL_FAILED" ] || [ -z "$RUN_RESPONSE" ]; then
+    echo "ERROR: curl request to trigger pipeline failed."
+    exit 1
+fi
+
+RUN_ID=$(echo "$RUN_RESPONSE"   | jq -r '.id   // empty')
+RUN_URL=$(echo "$RUN_RESPONSE"  | jq -r '._links.web.href // empty')
+
+if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+    echo "ERROR: Failed to parse run ID from response:"
+    echo "$RUN_RESPONSE"
+    exit 1
+fi
+
+echo ""
+echo "Pipeline run #${RUN_ID} triggered successfully."
+echo "View at: ${RUN_URL}"
+echo ""
+
+# ------------------------------------------------------------------
+# Poll for completion
+# ------------------------------------------------------------------
+MAX_ATTEMPTS=$(( TIMEOUT_MINUTES * 2 ))   # poll every 30 seconds
+ATTEMPT=0
+
+echo "Polling for completion (timeout: ${TIMEOUT_MINUTES} minutes)..."
+
+while [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; do
+    ATTEMPT=$(( ATTEMPT + 1 ))
+
+    STATUS_RESPONSE=$(curl -sf \
+        "${API_BASE}/pipelines/${ADO_PIPELINE_ID}/runs/${RUN_ID}?api-version=7.1" \
+        -H "${AUTH_HEADER}" || echo "CURL_FAILED")
+
+    if [ "$STATUS_RESPONSE" = "CURL_FAILED" ]; then
+        echo "[$(date -u '+%H:%M:%S')] WARNING: status poll failed, retrying..."
+        sleep 30
+        continue
+    fi
+
+    STATE=$(echo  "$STATUS_RESPONSE" | jq -r '.state  // "unknown"')
+    RESULT=$(echo "$STATUS_RESPONSE" | jq -r '.result // "unknown"')
+
+    echo "[$(date -u '+%H:%M:%S')] State: ${STATE} | Result: ${RESULT}  (attempt ${ATTEMPT}/${MAX_ATTEMPTS})"
+
+    if [ "$STATE" = "completed" ]; then
+        echo ""
+        echo "=============================================="
+        echo "  Pipeline run #${RUN_ID} completed."
+        echo "  Result: ${RESULT}"
+        echo "  URL:    ${RUN_URL}"
+        echo "=============================================="
+
+        if [ "$RESULT" = "succeeded" ]; then
+            echo "All E2E tests passed."
+            exit 0
+        else
+            echo "E2E tests FAILED (result: ${RESULT})."
+            exit 1
+        fi
+    fi
+
+    sleep 30
+done
+
+echo ""
+echo "ERROR: Timeout — pipeline did not complete within ${TIMEOUT_MINUTES} minutes."
+echo "View at: ${RUN_URL}"
+exit 1


### PR DESCRIPTION
…tension

Adds a GitHub Actions workflow + two ADO pipelines that automate the previously manual pre-release sanity check, and add the OIDC regression coverage that was missing when PR #608 introduced the OIDC bug (later fixed in #609).

Files added:
  - .github/workflows/e2e-plugin-tests.yml      3-job workflow: build/install,
                                                 sanity, OIDC. Triggered on the
                                                 "safe to test" PR label, with
                                                 a concurrency lock to prevent
                                                 two PRs racing in the dev org.
  - .pipelines/ado-sanity-pipeline.yml          Replaces the manual sanity test
                                                 (ToolsInstaller, GenericArtifacts
                                                 round-trip, Maven, BuildInfo,
                                                 DiscardBuilds).
  - .pipelines/ado-oidc-regression-pipeline.yml 9 parallel stages covering every
                                                 configure*Server() code path
                                                 with both OIDC and non-OIDC
                                                 service connections.
  - buildScripts/trigger-ado-pipeline.sh        Bridge script: triggers an ADO
                                                 pipeline via REST API and polls
                                                 for completion.

Files modified:
  - buildScripts/publish-private.sh             Adds optional EXTENSION_VERSION_OVERRIDE
                                                 so CI can publish a traceable
                                                 version (0.<PR>.<run>) instead
                                                 of random numbers.

Why
---
Before this change the project had no automated test that:
  * installed the built .vsix into a real Azure DevOps org
  * ran tasks as genuine Azure Pipelines steps
  * validated OIDC authentication for any task type

The OIDC regression in PR #608 went undetected because TaskMockRunner cannot simulate the Azure Pipelines agent or the jf eot OIDC token exchange.  The fix in #609 had no automated regression guard before this change.

One-time setup required (per dev org)
-------------------------------------
  * Create Marketplace publisher (https://aka.ms/vsm-create-publisher)
  * Create the 8 service connections + 14 Artifactory repos referenced in pipeline parameter defaults
  * Import both .pipelines/*.yml into ADO and record their definition IDs
  * Add 6 GitHub secrets: ADO_E2E_ORG, ADO_E2E_PAT, ADO_SANITY_PROJECT, ADO_SANITY_PIPELINE_ID, ADO_OIDC_PROJECT, ADO_OIDC_PIPELINE_ID

Per-PR usage
------------
A reviewer adds the "safe to test" label; the workflow then publishes a private .vsix tagged 0.<PR>.<run>, installs it into the dev org, and runs both ADO pipelines in parallel. Three new checks appear on the PR.

- [ ] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
