### PR TITLE
fix(e2e): use a distinct extension id for the private CI publish

### DIFF
--- a/.github/workflows/e2e-plugin-tests.yml
+++ b/.github/workflows/e2e-plugin-tests.yml
@@ -91,6 +91,12 @@ jobs:
           # ~65MB due to a known node_modules bloat regression tracked separately.
           # Marketplace will still enforce its own size limit at upload time.
           SKIP_VSIX_SIZE_CHECK: 'true'
+          # Use a distinct extension id for the private CI publish to avoid
+          # Marketplace's permanent record of the public id "jfrog-azure-devops-extension"
+          # rejecting our private creates with "The extension already exists".
+          # Tasks inside the .vsix are referenced by GUID so this is transparent
+          # to the pipeline test stages.
+          EXTENSION_ID_OVERRIDE: 'jfrog-azure-devops-extension-e2e'
         run: bash buildScripts/publish-private.sh
 
       - name: Print installed version for traceability

--- a/buildScripts/publish-private.sh
+++ b/buildScripts/publish-private.sh
@@ -43,7 +43,22 @@ cp vss-extension.json vss-extension-private.json
 # value silently wins, causing publishes to land in (or conflict with) the
 # wrong publisher. Editing the JSON in-place removes that ambiguity.
 sed -i.bak "s/\"publisher\": *\"[^\"]*\"/\"publisher\": \"$PUBLISHER\"/" vss-extension-private.json
+
+# Optionally override the extension id. Marketplace appears to keep a
+# permanent record of every (publisher, id) pair it has ever seen - even
+# after `tfx extension unpublish` returns success and the publisher UI
+# shows nothing, subsequent attempts to (re)create the same id fail with
+# "The extension already exists". Letting CI publish under a distinct id
+# (e.g. "jfrog-azure-devops-extension-e2e") sidesteps this entirely.
+# Tasks inside the .vsix are referenced by their own GUIDs, not by the
+# extension id, so this is safe.
+EXTENSION_ID="jfrog-azure-devops-extension"
+if [ -n "${EXTENSION_ID_OVERRIDE:-}" ]; then
+    EXTENSION_ID="$EXTENSION_ID_OVERRIDE"
+    sed -i.bak "s/\"id\": *\"jfrog-azure-devops-extension\"/\"id\": \"$EXTENSION_ID\"/" vss-extension-private.json
+fi
 rm -f vss-extension-private.json.bak
+export EXTENSION_ID
 
 # `tfx extension unpublish` removes the extension entirely from Marketplace.
 # We used to call it before every publish to keep the publisher tidy, but
@@ -54,8 +69,8 @@ rm -f vss-extension-private.json.bak
 # Set REPUBLISH_FROM_SCRATCH=true to restore the old behaviour for one-off
 # manual cleanups.
 if [ "${REPUBLISH_FROM_SCRATCH:-false}" = "true" ]; then
-    npx tfx extension unshare -t "$ADO_ARTIFACTORY_API_KEY" --extension-id jfrog-azure-devops-extension --publisher "$PUBLISHER" --unshare-with "$ADO_ARTIFACTORY_DEVELOPER" 2>/dev/null || true
-    npx tfx extension unpublish -t "$ADO_ARTIFACTORY_API_KEY" --extension-id jfrog-azure-devops-extension --publisher "$PUBLISHER" || true
+    npx tfx extension unshare -t "$ADO_ARTIFACTORY_API_KEY" --extension-id "$EXTENSION_ID" --publisher "$PUBLISHER" --unshare-with "$ADO_ARTIFACTORY_DEVELOPER" 2>/dev/null || true
+    npx tfx extension unpublish -t "$ADO_ARTIFACTORY_API_KEY" --extension-id "$EXTENSION_ID" --publisher "$PUBLISHER" || true
     MARKETPLACE_DELETE_WAIT_SECONDS="${MARKETPLACE_DELETE_WAIT_SECONDS:-60}"
     echo "Waiting ${MARKETPLACE_DELETE_WAIT_SECONDS}s for Marketplace to fully process the unpublish..."
     sleep "$MARKETPLACE_DELETE_WAIT_SECONDS"
@@ -95,7 +110,7 @@ while : ; do
     sleep "$PUBLISH_RETRY_WAIT_SECONDS"
     attempt=$((attempt + 1))
 done
-npx tfx extension install --publisher "$PUBLISHER" --extension-id jfrog-azure-devops-extension --service-url https://"$ADO_ARTIFACTORY_DEVELOPER".visualstudio.com -t "$ADO_ARTIFACTORY_API_KEY"
+npx tfx extension install --publisher "$PUBLISHER" --extension-id "$EXTENSION_ID" --service-url https://"$ADO_ARTIFACTORY_DEVELOPER".visualstudio.com -t "$ADO_ARTIFACTORY_API_KEY"
 
 rm -- *.vsix
 rm vss-extension-private.json


### PR DESCRIPTION
Even after PR #614 stopped calling `tfx extension unpublish`, the e2e workflow still fails at the publish step:

  Checking if this extension is already published
  It isn't, create a new extension.
  error: The extension already exists.

The retry loop and the manifest publisher fix did not help. The publisher UI is empty, but Marketplace's API persistently rejects new extensions with the id "jfrog-azure-devops-extension" on this private publisher - presumably because Marketplace reserves a permanent record of every (publisher, id) pair it has ever seen, and the first successful publish (run #4) left a record that no amount of waiting, retrying or unpublishing can clear within reasonable CI time.

Switch the CI build to a fresh extension id ("jfrog-azure-devops- extension-e2e") that Marketplace has never seen, so create succeeds the first time and version-bumps thereafter. Tasks inside the .vsix are referenced by their own GUIDs, not by the extension id, so the sanity and OIDC pipelines need no changes.

The new EXTENSION_ID_OVERRIDE env var keeps the manifest's original id the default for local manual usage, and is opted into only by the e2e workflow.

- [ ] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
