### PR TITLE
docs(readme): mention the e2e workflow + 'safe to test' label for mai…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1456,6 +1456,10 @@ To build and run the extension sources, please follow these steps:
 After the build process is completed, you'll find the `vsix` file in the project directory.
 The `vsix` file can be loaded into Azure DevOps and TFS.
 
+> Maintainers: PRs can also be exercised end-to-end by adding the `safe to test`
+> label, which runs `.github/workflows/e2e-plugin-tests.yml` against a dev ADO
+> organisation.
+
 </details>
 
 <details>


### PR DESCRIPTION
…ntainers

Trivial doc-only change. Also used as a dummy PR to smoke-test the new hybrid e2e workflow (build artifact + manual install + ADO pipeline triggers) introduced in #616.

- [ ] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
