### PR TITLE
e2e: rename private-build tasks with E2E suffix to fix ADO ambiguity

### DIFF
--- a/.github/workflows/e2e-plugin-tests.yml
+++ b/.github/workflows/e2e-plugin-tests.yml
@@ -113,35 +113,45 @@ jobs:
         # A failure here is a real PR failure (broken build).
         run: npm install --no-fund
 
-      - name: Rewrite task GUIDs for private build
-        # The public JFrog extension installed in the dev org uses the same
-        # task GUIDs as our source tree. ADO rejects installing a second
-        # extension that re-uses any task GUID ("already been uploaded by
-        # extension 'jfrog-azure-devops-extension'"). We replace every task
-        # GUID with a deterministic UUID v5 (namespace=our extension id +
-        # original GUID) so the private build has stable, unique GUIDs that
-        # never clash with the public extension, and are identical on every
-        # CI run (same branch → same GUIDs → installed extension's tasks
-        # are always found by the ADO pipeline YAML).
+      - name: Rewrite task GUIDs and names for private build
+        # The public JFrog extension uses the same task GUIDs and names as
+        # our source tree. Installing both in the same ADO org causes two
+        # problems:
+        #   1. Marketplace rejects publishing a .vsix whose task GUIDs are
+        #      already owned by another extension ("already been uploaded by
+        #      extension 'jfrog-azure-devops-extension'").
+        #   2. ADO rejects queuing a pipeline run when two installed
+        #      extensions export tasks with the same name ("task name
+        #      JFrogToolsInstaller is ambiguous").
+        # We fix both by rewriting every task.json:
+        #   • id   → deterministic UUIDv5 (namespace + original GUID)
+        #             stable across CI runs; unique vs the public extension.
+        #   • name → original name + "E2E" suffix
+        #             e.g. JFrogToolsInstaller → JFrogToolsInstallerE2E
+        #             The .pipelines/ado-*.yml files reference the E2E names
+        #             so the test pipelines always target this private build,
+        #             never the public one.
         run: |
           set -euo pipefail
           python3 - <<'PYEOF'
-          import json, uuid, glob, os
+          import json, uuid, glob
 
           # Fixed namespace — changing this would change all GUIDs.
           NS = uuid.UUID('e2e1a2b3-c4d5-6789-abcd-ef0123456789')
 
-          for path in sorted(glob.glob('tasks/*/task.json')):
+          paths = sorted(glob.glob('tasks/*/task.json'))
+          for path in paths:
               data = json.load(open(path))
-              orig = data.get('id', '')
-              if not orig:
+              orig_id   = data.get('id',   '')
+              orig_name = data.get('name', '')
+              if not orig_id:
                   continue
-              new_guid = str(uuid.uuid5(NS, orig))
-              data['id'] = new_guid
+              data['id']   = str(uuid.uuid5(NS, orig_id))
+              data['name'] = orig_name + 'E2E'
               json.dump(data, open(path, 'w'), indent=2)
-              print(f"  {orig}  →  {new_guid}  ({path})")
+              print(f"  {orig_name}  →  {data['name']}  |  {orig_id}  →  {data['id']}  ({path})")
 
-          print(f"Rewrote {len(glob.glob('tasks/*/task.json'))} task GUIDs.")
+          print(f"Rewrote {len(paths)} task GUIDs and names.")
           PYEOF
 
       - name: Package .vsix

--- a/.pipelines/ado-oidc-regression-pipeline.yml
+++ b/.pipelines/ado-oidc-regression-pipeline.yml
@@ -83,7 +83,7 @@ stages:
         steps:
           - script: echo "##[section]OIDC PR #$(GH_PR_NUMBER) commit $(GH_COMMIT_SHA)"
             displayName: 'Print traceability'
-          - task: JFrogCliV2@1
+          - task: JFrogCliV2E2E@1
             displayName: 'jf rt ping via Platform OIDC'
             inputs:
               jfrogPlatformConnection: 'sc-platform-oidc'
@@ -108,7 +108,7 @@ stages:
           - script: |
               echo "oidc test file PR=$(GH_PR_NUMBER) sha=$(GH_COMMIT_SHA)" > /tmp/oidc-a2.txt
             displayName: 'Create test file'
-          - task: JFrogGenericArtifacts@1
+          - task: JFrogGenericArtifactsE2E@1
             displayName: 'Upload via OIDC'
             inputs:
               command: Upload
@@ -131,7 +131,7 @@ stages:
         dependsOn: S2_A2_GenericUpload
         pool: { vmImage: 'ubuntu-22.04' }
         steps:
-          - task: JFrogGenericArtifacts@1
+          - task: JFrogGenericArtifactsE2E@1
             displayName: 'Download via OIDC'
             inputs:
               command: Download
@@ -158,7 +158,7 @@ stages:
         dependsOn: S2_A2_GenericUpload
         pool: { vmImage: 'ubuntu-22.04' }
         steps:
-          - task: JFrogPublishBuildInfo@1
+          - task: JFrogPublishBuildInfoE2E@1
             displayName: 'Publish build info via OIDC'
             inputs:
               artifactoryConnection: 'sc-artifactory-oidc'
@@ -172,7 +172,7 @@ stages:
         dependsOn: S2_A4_PublishBuildInfo
         pool: { vmImage: 'ubuntu-22.04' }
         steps:
-          - task: JFrogBuildPromotion@1
+          - task: JFrogBuildPromotionE2E@1
             displayName: 'Promote build (dry run)'
             inputs:
               artifactoryConnection: 'sc-artifactory-oidc'
@@ -188,7 +188,7 @@ stages:
         displayName: 'A_Discard DiscardBuilds (OIDC)'
         pool: { vmImage: 'ubuntu-22.04' }
         steps:
-          - task: JFrogDiscardBuilds@1
+          - task: JFrogDiscardBuildsE2E@1
             displayName: 'Discard old OIDC builds (keep last 5)'
             inputs:
               artifactoryConnection: 'sc-artifactory-oidc'
@@ -213,7 +213,7 @@ stages:
                 aggregationStatus: RELEASED
               EOF
             displayName: 'Write issue collection config'
-          - task: JFrogCollectIssues@1
+          - task: JFrogCollectIssuesE2E@1
             displayName: 'Collect issues (OIDC)'
             inputs:
               artifactoryConnection: 'sc-artifactory-oidc'
@@ -230,7 +230,7 @@ stages:
         displayName: 'A_ToolsInstaller via TOKEN [GUARD non-OIDC]'
         pool: { vmImage: 'ubuntu-22.04' }
         steps:
-          - task: JFrogToolsInstaller@1
+          - task: JFrogToolsInstallerE2E@1
             displayName: 'Install JFrog CLI via API token (non-OIDC)'
             inputs:
               artifactoryConnection: 'sc-artifactory-token'
@@ -244,7 +244,7 @@ stages:
         displayName: 'A_ToolsInstaller extractors via OIDC'
         pool: { vmImage: 'ubuntu-22.04' }
         steps:
-          - task: JFrogToolsInstaller@1
+          - task: JFrogToolsInstallerE2E@1
             displayName: 'Install CLI + Maven/Gradle extractors via OIDC'
             inputs:
               artifactoryConnection: 'sc-artifactory-oidc'
@@ -271,7 +271,7 @@ stages:
               }
               EOF
             displayName: 'Create test package.json'
-          - task: JFrogNpm@1
+          - task: JFrogNpmE2E@1
             displayName: 'npm install via OIDC'
             inputs:
               command: 'install'
@@ -290,7 +290,7 @@ stages:
           - task: UsePythonVersion@0
             displayName: 'Install Python 3.11'
             inputs: { versionSpec: '3.11' }
-          - task: JFrogPip@1
+          - task: JFrogPipE2E@1
             displayName: 'pip install via OIDC'
             inputs:
               artifactoryConnection: 'sc-artifactory-oidc'
@@ -319,7 +319,7 @@ stages:
               { "name": "audit-test", "version": "1.0.0", "dependencies": { "lodash": "4.17.20" } }
               EOF
             displayName: 'Create project for audit'
-          - task: JFrogAudit@1
+          - task: JFrogAuditE2E@1
             displayName: 'Audit via Xray OIDC'
             inputs:
               xrayConnection: 'sc-xray-oidc'
@@ -332,7 +332,7 @@ stages:
         displayName: 'A7 JFrogDocker Scan (Xray OIDC)'
         pool: { vmImage: 'ubuntu-22.04' }
         steps:
-          - task: JFrogDocker@1
+          - task: JFrogDockerE2E@1
             displayName: 'Docker scan via Xray OIDC'
             inputs:
               command: 'scan'
@@ -354,7 +354,7 @@ stages:
         displayName: 'JFrogDistribution dry-run (OIDC)'
         pool: { vmImage: 'ubuntu-22.04' }
         steps:
-          - task: JFrogDistribution@1
+          - task: JFrogDistributionE2E@1
             displayName: 'Create release bundle (dry run)'
             inputs:
               distributionConnection: 'sc-distribution-oidc'
@@ -408,7 +408,7 @@ stages:
               </project>
               EOF
             displayName: 'Create inline pom.xml'
-          - task: JFrogMaven@1
+          - task: JFrogMavenE2E@1
             displayName: 'Maven resolve + deploy via OIDC'
             inputs:
               mavenPOMFile: '/tmp/maven-oidc/pom.xml'
@@ -455,7 +455,7 @@ stages:
               dependencies { implementation 'org.apache.commons:commons-lang3:3.12.0' }
               EOF
             displayName: 'Create inline Gradle project'
-          - task: JFrogGradle@1
+          - task: JFrogGradleE2E@1
             displayName: 'Gradle build via OIDC'
             inputs:
               gradleBuildFile: '/tmp/gradle-oidc/build.gradle'
@@ -506,7 +506,7 @@ stages:
               func main() { fmt.Println(uuid.New().String()) }
               EOF
             displayName: 'Create inline Go module'
-          - task: JFrogGo@1
+          - task: JFrogGoE2E@1
             displayName: 'Go build via OIDC'
             inputs:
               command: 'build'
@@ -532,7 +532,7 @@ stages:
         steps:
           - script: echo "guard token PR=$(GH_PR_NUMBER)" > /tmp/guard-token.txt
             displayName: 'Create test file'
-          - task: JFrogGenericArtifacts@1
+          - task: JFrogGenericArtifactsE2E@1
             displayName: 'Upload via API token'
             inputs:
               command: Upload
@@ -552,7 +552,7 @@ stages:
         steps:
           - script: echo "guard basic PR=$(GH_PR_NUMBER)" > /tmp/guard-basic.txt
             displayName: 'Create test file'
-          - task: JFrogGenericArtifacts@1
+          - task: JFrogGenericArtifactsE2E@1
             displayName: 'Upload via basic auth'
             inputs:
               command: Upload
@@ -574,7 +574,7 @@ stages:
               mkdir -p /tmp/d3-audit && cd /tmp/d3-audit
               echo '{ "name":"d3","version":"1.0.0","dependencies":{"lodash":"4.17.20"} }' > package.json
             displayName: 'Create project'
-          - task: JFrogAudit@1
+          - task: JFrogAuditE2E@1
             displayName: 'Audit via Xray basic auth'
             inputs:
               xrayConnection: 'sc-xray-basic'
@@ -587,7 +587,7 @@ stages:
         displayName: 'D4 Distribution via BASIC AUTH dry-run [GUARD]'
         pool: { vmImage: 'ubuntu-22.04' }
         steps:
-          - task: JFrogDistribution@1
+          - task: JFrogDistributionE2E@1
             displayName: 'Create release bundle (dry run)'
             inputs:
               distributionConnection: 'sc-distribution-basic'
@@ -625,7 +625,7 @@ stages:
             displayName: 'Prepare test artifacts'
 
           # Task 1: upload via Artifactory OIDC ----------------------
-          - task: JFrogGenericArtifacts@1
+          - task: JFrogGenericArtifactsE2E@1
             displayName: 'Step 1 GenericArtifacts upload (Artifactory OIDC)'
             inputs:
               command: Upload
@@ -643,7 +643,7 @@ stages:
               buildNumber: '$(BUILD_NUMBER)'
 
           # Task 2: publish build info via Artifactory OIDC ----------
-          - task: JFrogPublishBuildInfo@1
+          - task: JFrogPublishBuildInfoE2E@1
             displayName: 'Step 2 PublishBuildInfo (Artifactory OIDC)'
             inputs:
               artifactoryConnection: 'sc-artifactory-oidc'
@@ -652,7 +652,7 @@ stages:
               excludeEnvVars: '*password*;*psw*;*secret*;*key*;*token*;*auth*'
 
           # Task 3: audit via Xray OIDC (different SC type) ----------
-          - task: JFrogAudit@1
+          - task: JFrogAuditE2E@1
             displayName: 'Step 3 Audit (Xray OIDC) — different SC type'
             inputs:
               xrayConnection: 'sc-xray-oidc'

--- a/.pipelines/ado-sanity-pipeline.yml
+++ b/.pipelines/ado-sanity-pipeline.yml
@@ -86,7 +86,7 @@ steps:
   # 1. Install JFrog CLI                                                #
   #    Verifies: JFrogToolsInstaller task works end-to-end.            #
   # ------------------------------------------------------------------ #
-  - task: JFrogToolsInstaller@1
+  - task: JFrogToolsInstallerE2E@1
     displayName: 'Install JFrog CLI'
     inputs:
       artifactoryConnection: 'jfrog-sanity-connection'
@@ -105,7 +105,7 @@ steps:
   - script: echo "sanity test file — PR $(GH_PR_NUMBER) — $(GH_COMMIT_SHA)" > /tmp/sanity.txt
     displayName: 'Create test file'
 
-  - task: JFrogGenericArtifacts@1
+  - task: JFrogGenericArtifactsE2E@1
     displayName: 'Upload test file'
     inputs:
       command: Upload
@@ -123,7 +123,7 @@ steps:
       buildNumber: '$(BUILD_NUMBER)'
       includeEnvVars: false
 
-  - task: JFrogGenericArtifacts@1
+  - task: JFrogGenericArtifactsE2E@1
     displayName: 'Download test file back'
     inputs:
       command: Download
@@ -163,7 +163,7 @@ steps:
       jdkArchitectureOption: 'x64'
       jdkSourceOption: 'PreInstalled'
 
-  - task: JFrogMaven@1
+  - task: JFrogMavenE2E@1
     displayName: 'Maven: resolve from Artifactory, deploy to Artifactory'
     inputs:
       mavenPOMFile: 'project-examples/maven-examples/maven-example/pom.xml'
@@ -183,7 +183,7 @@ steps:
   # 5. Publish Build Info                                               #
   #    Verifies: configureDefaultArtifactoryServer path.               #
   # ------------------------------------------------------------------ #
-  - task: JFrogPublishBuildInfo@1
+  - task: JFrogPublishBuildInfoE2E@1
     displayName: 'Publish Build Info'
     inputs:
       artifactoryConnection: 'jfrog-sanity-connection'
@@ -195,7 +195,7 @@ steps:
   # 6. Discard old builds (cleanup)                                     #
   #    Verifies: JFrogDiscardBuilds task + configureDefaultArtifactoryServer #
   # ------------------------------------------------------------------ #
-  - task: JFrogDiscardBuilds@1
+  - task: JFrogDiscardBuildsE2E@1
     displayName: 'Discard old sanity builds (keep last 5)'
     inputs:
       artifactoryConnection: 'jfrog-sanity-connection'


### PR DESCRIPTION
When both the public JFrog extension and our private test build are installed in the same ADO org, pipelines fail at queue time:

  "The task name JFrogToolsInstaller is ambiguous."

Root cause: the private build already has different task GUIDs (to pass Marketplace publish validation) but identical task *names*, so ADO cannot tell which extension's task to invoke.

Fix: extend the existing GUID-rewrite step to also append "E2E" to every task's `name` field (e.g. JFrogToolsInstaller → JFrogToolsInstallerE2E). Update both test pipeline YAMLs to reference the E2E-suffixed names.

Result: public and private extensions coexist in the same org with no name collision. The .pipelines/ado-*.yml files always target the private test build; the public extension is untouched.

- [ ] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
