### PR TITLE
fix(e2e): replace runtime coalesce expressions with simple variable d…

### DIFF
--- a/.pipelines/ado-oidc-regression-pipeline.yml
+++ b/.pipelines/ado-oidc-regression-pipeline.yml
@@ -63,8 +63,10 @@ trigger: none   # Only triggered via REST API from GitHub Actions.
 # below in-place.
 
 variables:
-  GH_PR_NUMBER:  $[coalesce(variables['GH_PR_NUMBER'],  '0')]
-  GH_COMMIT_SHA: $[coalesce(variables['GH_COMMIT_SHA'], 'unknown')]
+  # Defaults — overridden at queue time by the GitHub Actions trigger script.
+  # These must also be marked "Settable at queue time" in the pipeline UI.
+  GH_PR_NUMBER:  '0'
+  GH_COMMIT_SHA: 'unknown'
   BUILD_NAME:    'oidc-pr$(GH_PR_NUMBER)-$(Build.BuildId)'
   BUILD_NUMBER:  '$(Build.BuildNumber)'
 

--- a/.pipelines/ado-sanity-pipeline.yml
+++ b/.pipelines/ado-sanity-pipeline.yml
@@ -53,9 +53,10 @@ trigger: none   # Only triggered via REST API from GitHub Actions.
 # connection name, edit the literal below or fork this pipeline.
 
 variables:
-  # Passed in by GitHub Actions via the pipeline run API variables field.
-  GH_PR_NUMBER:  $[coalesce(variables['GH_PR_NUMBER'],  '0')]
-  GH_COMMIT_SHA: $[coalesce(variables['GH_COMMIT_SHA'], 'unknown')]
+  # Defaults — overridden at queue time by the GitHub Actions trigger script.
+  # These must also be marked "Settable at queue time" in the pipeline UI.
+  GH_PR_NUMBER:  '0'
+  GH_COMMIT_SHA: 'unknown'
   BUILD_NAME:    'sanity-pr$(GH_PR_NUMBER)-$(Build.BuildId)'
   BUILD_NUMBER:  '$(Build.BuildNumber)'
 


### PR DESCRIPTION
…efaults

The $[coalesce(variables[...], default)] syntax in the variables block expands as a literal string when referenced via $(VAR) macros in script steps, causing bash syntax errors. Since GH_PR_NUMBER and GH_COMMIT_SHA are now marked 'Settable at queue time' in both pipelines, simple static defaults are sufficient — the trigger script overrides them at queue time.

- [ ] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
