### PR TITLE
fix(e2e): fix S1 traceability script causing bash parse error

### DIFF
--- a/.pipelines/ado-oidc-regression-pipeline.yml
+++ b/.pipelines/ado-oidc-regression-pipeline.yml
@@ -83,7 +83,8 @@ stages:
         displayName: 'CliV2 ping (Platform OIDC)'
         pool: { vmImage: 'ubuntu-22.04' }
         steps:
-          - script: echo "##[section]OIDC PR #$(GH_PR_NUMBER) commit $(GH_COMMIT_SHA)"
+          - script: |
+              echo "OIDC PR #$GH_PR_NUMBER commit $GH_COMMIT_SHA"
             displayName: 'Print traceability'
           - task: JfrogCliV2E2E@1
             displayName: 'jf rt ping via Platform OIDC'


### PR DESCRIPTION
The single-line script:
  script: echo "##[section]OIDC PR #$(GH_PR_NUMBER) commit $(GH_COMMIT_SHA)"
was causing bash to fail with 'unexpected EOF while looking for matching "'. The ##[section] ADO log command embedded inside a double-quoted string in a single-line YAML scalar causes the ADO agent to strip the log command from the script source, leaving an unclosed double-quote that bash cannot parse.

Fix: switch to a |block scalar and use bash env var syntax ($GH_PR_NUMBER) so ADO does not macro-expand the variable before writing the script, avoiding the parse issue entirely.

- [ ] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
