### PR TITLE
Rteco 813 azure supportability with node js version 22

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu, windows ]
-        node-version: [ '16', '20', '24' ]
+        node-version: [ '16', '20', '22', '24' ]
         include:
           - os: windows
             extraSkipTests: ",conan"


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
Added azure supportability with node js version 22 on test workflows.