### PR TITLE
fix(JFrogToolsInstaller): authenticate CLI download for OIDC service connections

### DIFF
--- a/jfrog-tasks-utils/utils.d.ts
+++ b/jfrog-tasks-utils/utils.d.ts
@@ -63,10 +63,7 @@ declare module '@jfrog/tasks-utils' {
     export function addTrailingSlashIfNeeded(str: string): string;
     export function buildCliArtifactoryDownloadUrl(rtUrl: string, repoName: string, cliVersion?: string): string;
     export function createAuthHandlers(serviceConnection: string): ifm.IRequestHandler[];
-    export function createCliDownloadAuthHandlers(
-        serviceConnection: string,
-        exchangeFn?: (service: string, platformUrl: string, oidcProviderName: string) => Promise<string>,
-    ): Promise<ifm.IRequestHandler[]>;
+    export function createCliDownloadAuthHandlers(serviceConnection: string, exchangeFn?: (service: string, platformUrl: string, oidcProviderName: string) => Promise<string>,): Promise<ifm.IRequestHandler[]>;
     export function exchangeOidcTokenViaRest(service: string, platformUrl: string, oidcProviderName: string): Promise<string>;
     export function isOidcConnection(serviceConnection: string): boolean;
     export function resolvePlatformUrl(service: string): string;

--- a/jfrog-tasks-utils/utils.d.ts
+++ b/jfrog-tasks-utils/utils.d.ts
@@ -6,7 +6,7 @@ declare module '@jfrog/tasks-utils' {
         runTaskFunc: (cliPath: string) => void | Promise<void>,
         cliVersion?: string,
         cliDownloadUrl?: string,
-        cliAuthHandlers?: ifm.IRequestHandler[],
+        cliAuthHandlers?: ifm.IRequestHandler[] | (() => Promise<ifm.IRequestHandler[]>),
     ): void;
     export function quote(str: string): string;
     export function downloadCli(cliDownloadUrl?: string, cliAuthHandlers?: ifm.IRequestHandler[], cliVersion?: string): Promise<string>;
@@ -63,6 +63,13 @@ declare module '@jfrog/tasks-utils' {
     export function addTrailingSlashIfNeeded(str: string): string;
     export function buildCliArtifactoryDownloadUrl(rtUrl: string, repoName: string, cliVersion?: string): string;
     export function createAuthHandlers(serviceConnection: string): ifm.IRequestHandler[];
+    export function createCliDownloadAuthHandlers(
+        serviceConnection: string,
+        exchangeFn?: (service: string, platformUrl: string, oidcProviderName: string) => Promise<string>,
+    ): Promise<ifm.IRequestHandler[]>;
+    export function exchangeOidcTokenViaRest(service: string, platformUrl: string, oidcProviderName: string): Promise<string>;
+    export function isOidcConnection(serviceConnection: string): boolean;
+    export function resolvePlatformUrl(service: string): string;
     export function stripTrailingSlash(str: string): string;
     export function writeSpecContentToSpecPath(specSource: string, specPath: string): void;
     export function addCommonGenericParams(cliCommand: string, specPath: string): string;

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -201,6 +201,8 @@ module.exports = {
     isToolExists: isToolExists,
     buildCliArtifactoryDownloadUrl: buildCliArtifactoryDownloadUrl,
     createAuthHandlers: createAuthHandlers,
+    createCliDownloadAuthHandlers: createCliDownloadAuthHandlers,
+    exchangeOidcTokenViaRest: exchangeOidcTokenViaRest,
     taskDefaultCleanup: taskDefaultCleanup,
     writeSpecContentToSpecPath: writeSpecContentToSpecPath,
     stripTrailingSlash: stripTrailingSlash,
@@ -285,7 +287,11 @@ function getCliPath(cliDownloadUrl, cliAuthHandlers, cliVersion) {
         } else {
             const errMsg = generateDownloadCliErrorMessage(cliDownloadUrl, cliVersion);
             createCliDirs();
-            return downloadCli(cliDownloadUrl, cliAuthHandlers, cliVersion)
+            // cliAuthHandlers may be an array or a provider function returning a Promise<array>.
+            // Resolve it lazily here so that work such as an OIDC token exchange only happens
+            // when a download is actually required — never when the CLI is already cached.
+            return Promise.resolve(typeof cliAuthHandlers === 'function' ? cliAuthHandlers() : cliAuthHandlers)
+                .then((resolvedHandlers) => downloadCli(cliDownloadUrl, resolvedHandlers, cliVersion))
                 .then((cliPath) => resolve(cliPath))
                 .catch((error) => reject(errMsg + '\n' + error));
         }
@@ -328,6 +334,33 @@ function createAuthHandlers(serviceConnection) {
 
     // Use basic authentication.
     return [new credentialsHandler.BasicCredentialHandler(artifactoryUser, artifactoryPassword, false)];
+}
+
+/**
+ * Builds the authentication handlers used to download the JFrog CLI.
+ *
+ * For OIDC-based service connections the credential does not exist as a static
+ * token — it must be obtained through an OIDC token exchange. The CLI-based
+ * exchange (exchangeOidcTokenAndSetStepVariables) cannot be used here because the
+ * CLI is the very artifact being downloaded, so this performs a CLI-independent
+ * REST exchange (exchangeOidcTokenViaRest) and authenticates the download with the
+ * resulting access token. For all other connection types it falls back to the
+ * synchronous createAuthHandlers (access token / basic / anonymous).
+ *
+ * @param {string} serviceConnection - The Artifactory service connection ID.
+ * @param {(service: string, platformUrl: string, oidcProviderName: string) => Promise<string>} [exchangeFn]
+ *        - OIDC exchange implementation; injectable for testing. Defaults to exchangeOidcTokenViaRest.
+ * @returns {Promise<Array>} Authentication handlers for the CLI download.
+ */
+async function createCliDownloadAuthHandlers(serviceConnection, exchangeFn = exchangeOidcTokenViaRest) {
+    const oidcProviderName = tl.getEndpointAuthorizationParameter(serviceConnection, 'oidcProviderName', true);
+    if (!oidcProviderName) {
+        // Not an OIDC connection - use the existing static-credential handlers.
+        return createAuthHandlers(serviceConnection);
+    }
+    const platformUrl = resolvePlatformUrl(serviceConnection);
+    const accessToken = await exchangeFn(serviceConnection, platformUrl, oidcProviderName);
+    return [new credentialsHandler.BearerCredentialHandler(accessToken, false)];
 }
 
 function generateDownloadCliErrorMessage(downloadUrl, cliVersion) {
@@ -393,11 +426,14 @@ function maskSecrets(str) {
         .replace(/--access-token='.*?'/g, '--access-token=***');
 }
 
-async function fetchOidcTokenIfConfigured(service, cliPath, buildDir) {
-    const oidcProviderName = tl.getEndpointAuthorizationParameter(service, 'oidcProviderName', true);
-    if (!oidcProviderName) {
-        return undefined;
-    }
+/**
+ * Resolves the JFrog platform URL for a service connection. Prefers the explicit
+ * 'jfrogPlatformUrl' authorization parameter and falls back to parsing it from the
+ * service URL.
+ * @param {string} service - The service connection ID.
+ * @returns {string} The resolved platform URL.
+ */
+function resolvePlatformUrl(service) {
     const serviceUrl = tl.getEndpointUrl(service, false);
     let platformUrl = '';
     try {
@@ -408,6 +444,15 @@ async function fetchOidcTokenIfConfigured(service, cliPath, buildDir) {
     if (!platformUrl || !platformUrl.trim()) {
         platformUrl = parsePlatformUrlFromServiceUrl(serviceUrl);
     }
+    return platformUrl;
+}
+
+async function fetchOidcTokenIfConfigured(service, cliPath, buildDir) {
+    const oidcProviderName = tl.getEndpointAuthorizationParameter(service, 'oidcProviderName', true);
+    if (!oidcProviderName) {
+        return undefined;
+    }
+    const platformUrl = resolvePlatformUrl(service);
     return exchangeOidcTokenAndSetStepVariables(service, platformUrl, oidcProviderName, cliPath, buildDir);
 }
 
@@ -617,6 +662,58 @@ async function fetchAzureOidcToken(serviceConnectionID) {
     }
     debugLogIDToken(body.oidcToken);
     return body.oidcToken;
+}
+
+/**
+ * Performs an OIDC token exchange WITHOUT the JFrog CLI, via a direct REST call to
+ * JFrog Access. Required by the JFrog Tools Installer, which must authenticate the
+ * CLI *download* itself — at that point the CLI does not yet exist, so the
+ * CLI-based exchange cannot be used. The request mirrors what `jf eot` sends for an
+ * Azure provider (grant_type / subject_token_type / subject_token / provider_name /
+ * provider_type / audience). The Azure DevOps identity mapping is matched on the ID
+ * token's subject claim, which is carried in subject_token.
+ *
+ * @param {string} service - The service connection ID.
+ * @param {string} platformUrl - The JFrog platform base URL.
+ * @param {string} oidcProviderName - The configured OIDC provider name.
+ * @returns {Promise<string>} The exchanged JFrog access token.
+ */
+async function exchangeOidcTokenViaRest(service, platformUrl, oidcProviderName) {
+    const oidcAudience = tl.getEndpointAuthorizationParameter(service, 'oidcAudience', true) || 'api://AzureADTokenExchange';
+    const idToken = await fetchAzureOidcToken(service);
+
+    const exchangeUrl = addTrailingSlashIfNeeded(platformUrl) + 'access/api/v1/oidc/token';
+    const requestBody = {
+        grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+        subject_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+        subject_token: idToken,
+        provider_name: oidcProviderName,
+        provider_type: 'Azure',
+        audience: oidcAudience,
+    };
+
+    const requestOptions = { ...getProxyConfiguration(), socketTimeout: 30000 };
+    const httpClient = new httpm.HttpClient(buildAgent, [], requestOptions);
+    tl.debug('Exchanging OIDC token via REST at: ' + exchangeUrl);
+    const response = await httpClient.post(exchangeUrl, JSON.stringify(requestBody), {
+        'Content-Type': 'application/json',
+    });
+
+    const statusCode = response.message.statusCode;
+    const responseBody = await response.readBody();
+    if (statusCode !== 200) {
+        throw new Error(`OIDC token exchange failed: HTTP ${statusCode}\nBody: ${responseBody}`);
+    }
+    /** @type {{ access_token?: string, username?: string }} */
+    const body = JSON.parse(responseBody);
+    if (!body.access_token) {
+        throw new Error('OIDC token exchange response did not contain an access token.');
+    }
+
+    // Publish outputs for parity with the CLI-based OIDC flow (downstream consumption / debug).
+    tl.setVariable(oidcUserOutputName, body.username || '', true);
+    tl.setVariable(oidcTokenOutputName, body.access_token, true);
+    return body.access_token;
 }
 
 async function exchangeOidcTokenAndSetStepVariables(service, serviceUrl, oidcProviderName, cliPath, buildDir) {

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -203,6 +203,8 @@ module.exports = {
     createAuthHandlers: createAuthHandlers,
     createCliDownloadAuthHandlers: createCliDownloadAuthHandlers,
     exchangeOidcTokenViaRest: exchangeOidcTokenViaRest,
+    isOidcConnection: isOidcConnection,
+    resolvePlatformUrl: resolvePlatformUrl,
     taskDefaultCleanup: taskDefaultCleanup,
     writeSpecContentToSpecPath: writeSpecContentToSpecPath,
     stripTrailingSlash: stripTrailingSlash,
@@ -337,6 +339,15 @@ function createAuthHandlers(serviceConnection) {
 }
 
 /**
+ * Returns whether the given service connection uses OIDC authentication.
+ * @param {string} serviceConnection - The service connection ID.
+ * @returns {boolean}
+ */
+function isOidcConnection(serviceConnection) {
+    return !!tl.getEndpointAuthorizationParameter(serviceConnection, 'oidcProviderName', true);
+}
+
+/**
  * Builds the authentication handlers used to download the JFrog CLI.
  *
  * For OIDC-based service connections the credential does not exist as a static
@@ -353,12 +364,11 @@ function createAuthHandlers(serviceConnection) {
  * @returns {Promise<Array>} Authentication handlers for the CLI download.
  */
 async function createCliDownloadAuthHandlers(serviceConnection, exchangeFn = exchangeOidcTokenViaRest) {
-    const oidcProviderName = tl.getEndpointAuthorizationParameter(serviceConnection, 'oidcProviderName', true);
-    if (!oidcProviderName) {
-        // Not an OIDC connection - use the existing static-credential handlers.
+    if (!isOidcConnection(serviceConnection)) {
         return createAuthHandlers(serviceConnection);
     }
     const platformUrl = resolvePlatformUrl(serviceConnection);
+    const oidcProviderName = tl.getEndpointAuthorizationParameter(serviceConnection, 'oidcProviderName', true);
     const accessToken = await exchangeFn(serviceConnection, platformUrl, oidcProviderName);
     return [new credentialsHandler.BearerCredentialHandler(accessToken, false)];
 }
@@ -448,10 +458,10 @@ function resolvePlatformUrl(service) {
 }
 
 async function fetchOidcTokenIfConfigured(service, cliPath, buildDir) {
-    const oidcProviderName = tl.getEndpointAuthorizationParameter(service, 'oidcProviderName', true);
-    if (!oidcProviderName) {
+    if (!isOidcConnection(service)) {
         return undefined;
     }
+    const oidcProviderName = tl.getEndpointAuthorizationParameter(service, 'oidcProviderName', true);
     const platformUrl = resolvePlatformUrl(service);
     return exchangeOidcTokenAndSetStepVariables(service, platformUrl, oidcProviderName, cliPath, buildDir);
 }

--- a/tasks/JFrogToolsInstaller/toolsInstaller.js
+++ b/tasks/JFrogToolsInstaller/toolsInstaller.js
@@ -21,8 +21,11 @@ function InstallCliAndExecuteCliTask(RunTaskCbk) {
     // Set the requested CLI version env to download it now, and to use in succeeding tasks.
     tl.setVariable(utils.pipelineRequestedCliVersionEnv, cliVersion);
     let downloadUrl = utils.buildCliArtifactoryDownloadUrl(artifactoryUrl, cliInstallationRepo, cliVersion);
-    let authHandlers = utils.createAuthHandlers(artifactoryService);
-    utils.executeCliTask(RunTaskCbk, cliVersion, downloadUrl, authHandlers);
+    // Pass a provider (resolved lazily by executeCliTask only if a download is needed).
+    // For OIDC service connections this performs a CLI-independent OIDC token exchange so
+    // the CLI download itself is authenticated; other connection types use static credentials.
+    let authHandlersProvider = () => utils.createCliDownloadAuthHandlers(artifactoryService);
+    utils.executeCliTask(RunTaskCbk, cliVersion, downloadUrl, authHandlersProvider);
 }
 
 async function RunTaskCbk(cliPath) {

--- a/tests/package.json
+++ b/tests/package.json
@@ -22,7 +22,8 @@
         "null-writable": "^1.0.5",
         "rimraf": "^6.1.2",
         "sync-request": "^6.1.0",
-        "ts-node": "^10.9.1"
+        "ts-node": "^10.9.1",
+        "typescript": "^5.2.2"
     },
     "scripts": {
         "test": "npm i && mocha -r ts-node/register tests.ts -t 1000000"

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -8,6 +8,7 @@ import * as syncRequest from 'sync-request';
 import * as TestUtils from './testUtils';
 import { platformDockerDomain } from './testUtils';
 import * as toolLib from 'azure-pipelines-tool-lib/tool';
+import * as taskLib from 'azure-pipelines-task-lib/task';
 import * as assert from 'assert';
 import * as os from 'os';
 import conanUtils from '../tasks/JFrogConan/conanUtils';
@@ -105,6 +106,76 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                 assert.strictEqual(jfrogUtils.cliJoin('jf', 'rt', 'u', 'a/b/c', 'a/b/c'), 'jf rt u a/b/c a/b/c');
                 assert.strictEqual(jfrogUtils.cliJoin('jf', 'rt', 'u', 'a\bc', 'a\bc'), 'jf rt u a\bc a\bc');
                 assert.strictEqual(jfrogUtils.cliJoin('jf', 'rt', 'u', 'a\\bc\\', 'a\\bc\\'), 'jf rt u a\\bc\\ a\\bc\\');
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'OIDC CLI download builds a Bearer handler from the exchanged token',
+            async (): Promise<void> => {
+                // Regression: JFrogToolsInstaller downloaded the CLI anonymously for OIDC
+                // service connections (createAuthHandlers returned []), causing HTTP 401.
+                // It must instead perform an OIDC token exchange and authenticate the
+                // download with the resulting access token.
+                const anyTl: any = taskLib;
+                const origGetParam: unknown = anyTl.getEndpointAuthorizationParameter;
+                const origGetUrl: unknown = anyTl.getEndpointUrl;
+                try {
+                    anyTl.getEndpointUrl = (): string => 'https://example.jfrog.io/artifactory';
+                    anyTl.getEndpointAuthorizationParameter = (id: string, key: string): string | undefined => {
+                        const params: { [k: string]: string } = {
+                            oidcProviderName: 'my-azure-oidc',
+                            oidcAudience: 'api://AzureADTokenExchange',
+                            jfrogPlatformUrl: 'https://example.jfrog.io',
+                        };
+                        return params[key];
+                    };
+                    let exchanged: { service: string; platformUrl: string; providerName: string } | undefined;
+                    const fakeExchange: (service: string, platformUrl: string, providerName: string) => Promise<string> = async (
+                        service: string,
+                        platformUrl: string,
+                        providerName: string,
+                    ): Promise<string> => {
+                        exchanged = { service, platformUrl, providerName };
+                        return 'EXCHANGED_ACCESS_TOKEN';
+                    };
+                    const handlers: any[] = await (jfrogUtils as any).createCliDownloadAuthHandlers('svc', fakeExchange);
+                    assert.strictEqual(handlers.length, 1, 'expected exactly one auth handler');
+                    assert.strictEqual(handlers[0].constructor.name, 'BearerCredentialHandler', 'expected a Bearer handler');
+                    assert.strictEqual(handlers[0].token, 'EXCHANGED_ACCESS_TOKEN', 'Bearer handler must carry the exchanged token');
+                    assert.ok(exchanged, 'OIDC exchange must be invoked');
+                    assert.strictEqual(exchanged!.providerName, 'my-azure-oidc');
+                    assert.strictEqual(exchanged!.platformUrl, 'https://example.jfrog.io');
+                } finally {
+                    anyTl.getEndpointAuthorizationParameter = origGetParam;
+                    anyTl.getEndpointUrl = origGetUrl;
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'Non-OIDC CLI download uses static credentials without an exchange',
+            async (): Promise<void> => {
+                const anyTl: any = taskLib;
+                const origGetParam: unknown = anyTl.getEndpointAuthorizationParameter;
+                try {
+                    anyTl.getEndpointAuthorizationParameter = (id: string, key: string): string | undefined =>
+                        key === 'apitoken' ? 'STATIC_TOKEN' : undefined;
+                    let exchanged: boolean = false;
+                    const handlers: any[] = await (jfrogUtils as any).createCliDownloadAuthHandlers(
+                        'svc',
+                        async (): Promise<string> => {
+                            exchanged = true;
+                            return 'unused';
+                        },
+                    );
+                    assert.strictEqual(exchanged, false, 'must not perform an OIDC exchange for a token connection');
+                    assert.strictEqual(handlers[0].constructor.name, 'BearerCredentialHandler');
+                    assert.strictEqual(handlers[0].token, 'STATIC_TOKEN');
+                } finally {
+                    anyTl.getEndpointAuthorizationParameter = origGetParam;
+                }
             },
             TestUtils.isSkipTest('unit'),
         );

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -9,6 +9,7 @@ import * as TestUtils from './testUtils';
 import { platformDockerDomain } from './testUtils';
 import * as toolLib from 'azure-pipelines-tool-lib/tool';
 import * as taskLib from 'azure-pipelines-task-lib/task';
+import * as httpm from 'typed-rest-client/HttpClient';
 import * as assert from 'assert';
 import * as os from 'os';
 import conanUtils from '../tasks/JFrogConan/conanUtils';
@@ -281,6 +282,151 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                     anyTl.getEndpointAuthorizationParameter = origGetParam;
                     anyTl.getEndpointUrl = origGetUrl;
                     (toolLib as any).findLocalTool = origFindLocalTool;
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'exchangeOidcTokenViaRest posts the correct request and returns the access token',
+            async (): Promise<void> => {
+                const stub: ReturnType<typeof stubExchangeHttp> = stubExchangeHttp(
+                    200,
+                    JSON.stringify({ access_token: 'JFROG_ACCESS_TOKEN', username: 'agrasth' }),
+                );
+                try {
+                    const token: string = await jfrogUtils.exchangeOidcTokenViaRest('svc', 'https://example.jfrog.io', 'my-provider');
+                    assert.strictEqual(token, 'JFROG_ACCESS_TOKEN', 'must return the exchanged access token');
+
+                    const exchangeCall: { url: string; body: { [k: string]: string } } | undefined = stub.postCalls.find(
+                        (c: { url: string; body: { [k: string]: string } }) => c.url.indexOf('/access/api/v1/oidc/token') !== -1,
+                    );
+                    assert.ok(exchangeCall, 'must POST to the JFrog Access OIDC token endpoint');
+                    assert.strictEqual(exchangeCall!.url, 'https://example.jfrog.io/access/api/v1/oidc/token', 'exchange URL must be correct');
+                    assert.strictEqual(exchangeCall!.body.grant_type, 'urn:ietf:params:oauth:grant-type:token-exchange');
+                    assert.strictEqual(exchangeCall!.body.subject_token_type, 'urn:ietf:params:oauth:token-type:id_token');
+                    assert.strictEqual(exchangeCall!.body.subject_token, stub.adoToken, 'must forward the ADO ID token as subject_token');
+                    assert.strictEqual(exchangeCall!.body.provider_name, 'my-provider');
+                    assert.strictEqual(exchangeCall!.body.provider_type, 'Azure');
+                    assert.strictEqual(exchangeCall!.body.audience, 'api://AzureADTokenExchange');
+                    assert.strictEqual(stub.outputs['oidc_token'], 'JFROG_ACCESS_TOKEN', 'must publish the oidc_token output variable');
+                } finally {
+                    stub.restore();
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'exchangeOidcTokenViaRest throws a clear error on a non-200 JFrog response',
+            async (): Promise<void> => {
+                const stub: ReturnType<typeof stubExchangeHttp> = stubExchangeHttp(
+                    403,
+                    JSON.stringify({ errors: [{ code: 'FORBIDDEN', message: 'Forbidden' }] }),
+                );
+                try {
+                    await assert.rejects(
+                        () => jfrogUtils.exchangeOidcTokenViaRest('svc', 'https://example.jfrog.io', 'my-provider'),
+                        /OIDC token exchange failed: HTTP 403/,
+                    );
+                } finally {
+                    stub.restore();
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'exchangeOidcTokenViaRest throws when the JFrog response has no access_token',
+            async (): Promise<void> => {
+                const stub: ReturnType<typeof stubExchangeHttp> = stubExchangeHttp(200, JSON.stringify({ token_type: 'Bearer' }));
+                try {
+                    await assert.rejects(
+                        () => jfrogUtils.exchangeOidcTokenViaRest('svc', 'https://example.jfrog.io', 'my-provider'),
+                        /did not contain an access token/,
+                    );
+                } finally {
+                    stub.restore();
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'CLI download resolves a function auth-provider to an array before downloadTool (guards handlers.forEach regression)',
+            async (): Promise<void> => {
+                const anyToolLib: any = toolLib;
+                const savedFind: unknown = anyToolLib.findLocalTool;
+                const savedDownload: unknown = anyToolLib.downloadTool;
+                const savedCache: unknown = anyToolLib.cacheFile;
+                const cacheDir: string = fs.mkdtempSync(join(os.tmpdir(), 'jfdl-'));
+                fs.writeFileSync(join(cacheDir, TestUtils.isWindows() ? 'jf.exe' : 'jf'), '#!/bin/sh\necho\n');
+                let captured: unknown = 'UNSET';
+                try {
+                    anyToolLib.findLocalTool = (): string => ''; // force a download
+                    anyToolLib.downloadTool = (_url: string, _dest: unknown, handlers: unknown): Promise<string> => {
+                        captured = handlers;
+                        return Promise.resolve(join(cacheDir, 'download.bin'));
+                    };
+                    anyToolLib.cacheFile = (): Promise<string> => Promise.resolve(cacheDir);
+
+                    const provider: () => Promise<any[]> = async (): Promise<any[]> => [{ marker: 'RESOLVED' }];
+                    await new Promise<void>((resolve, reject) => {
+                        jfrogUtils.executeCliTask(
+                            (): void => resolve(),
+                            '2.111.0',
+                            'https://example.jfrog.io/artifactory/repo/2.111.0/jfrog-cli-linux-amd64/jf',
+                            provider,
+                        );
+                        setTimeout(() => reject(new Error('executeCliTask did not invoke callback within 5s')), 5000);
+                    });
+                    assert.ok(Array.isArray(captured), 'downloadTool must receive an ARRAY, not a function (guards this.handlers.forEach)');
+                    assert.strictEqual((captured as any[])[0].marker, 'RESOLVED', 'the resolved provider result must reach downloadTool');
+                } finally {
+                    anyToolLib.findLocalTool = savedFind;
+                    anyToolLib.downloadTool = savedDownload;
+                    anyToolLib.cacheFile = savedCache;
+                    fs.rmSync(cacheDir, { recursive: true, force: true });
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'CLI download passes a plain array auth-handler through unchanged (backward compat)',
+            async (): Promise<void> => {
+                const anyToolLib: any = toolLib;
+                const savedFind: unknown = anyToolLib.findLocalTool;
+                const savedDownload: unknown = anyToolLib.downloadTool;
+                const savedCache: unknown = anyToolLib.cacheFile;
+                const cacheDir: string = fs.mkdtempSync(join(os.tmpdir(), 'jfdl-'));
+                fs.writeFileSync(join(cacheDir, TestUtils.isWindows() ? 'jf.exe' : 'jf'), '#!/bin/sh\necho\n');
+                let captured: unknown = 'UNSET';
+                try {
+                    anyToolLib.findLocalTool = (): string => '';
+                    anyToolLib.downloadTool = (_url: string, _dest: unknown, handlers: unknown): Promise<string> => {
+                        captured = handlers;
+                        return Promise.resolve(join(cacheDir, 'download.bin'));
+                    };
+                    anyToolLib.cacheFile = (): Promise<string> => Promise.resolve(cacheDir);
+
+                    const plainHandlers: any[] = [{ marker: 'PLAIN_ARRAY' }];
+                    await new Promise<void>((resolve, reject) => {
+                        jfrogUtils.executeCliTask(
+                            (): void => resolve(),
+                            '2.111.0',
+                            'https://example.jfrog.io/artifactory/repo/2.111.0/jfrog-cli-linux-amd64/jf',
+                            plainHandlers,
+                        );
+                        setTimeout(() => reject(new Error('executeCliTask did not invoke callback within 5s')), 5000);
+                    });
+                    assert.ok(Array.isArray(captured), 'downloadTool must receive the array');
+                    assert.strictEqual((captured as any[])[0].marker, 'PLAIN_ARRAY', 'existing array handlers must pass through unchanged');
+                } finally {
+                    anyToolLib.findLocalTool = savedFind;
+                    anyToolLib.downloadTool = savedDownload;
+                    anyToolLib.cacheFile = savedCache;
+                    fs.rmSync(cacheDir, { recursive: true, force: true });
                 }
             },
             TestUtils.isSkipTest('unit'),
@@ -1176,6 +1322,66 @@ function distributionCleanUp(rbName: string, rbVersion: string): void {
  * @param testFunc (Function) - The test logic
  * @param skip (Boolean, Optional) - True if test should be skipped
  */
+/**
+ * Stubs the shared task-lib + typed-rest-client HttpClient so the REAL
+ * exchangeOidcTokenViaRest can be exercised offline. The first POST (to the ADO
+ * `/oidctoken` endpoint, made by fetchAzureOidcToken) always returns a fake ADO
+ * ID token; the second POST (to JFrog Access) returns the provided status/body.
+ * Returns captured POST calls, published output variables, the fake ADO token,
+ * and a restore() to undo all stubbing.
+ */
+function stubExchangeHttp(
+    exchangeStatus: number,
+    exchangeBody: string,
+): {
+    postCalls: Array<{ url: string; body: { [k: string]: string } }>;
+    outputs: { [k: string]: string };
+    adoToken: string;
+    restore: () => void;
+} {
+    const anyTl: any = taskLib;
+    const anyHttp: any = httpm;
+    const savedGetVariable: unknown = anyTl.getVariable;
+    const savedGetParam: unknown = anyTl.getEndpointAuthorizationParameter;
+    const savedSetVariable: unknown = anyTl.setVariable;
+    const savedHttpClient: unknown = anyHttp.HttpClient;
+
+    const postCalls: Array<{ url: string; body: { [k: string]: string } }> = [];
+    const outputs: { [k: string]: string } = {};
+    const adoToken: string =
+        'h.' +
+        Buffer.from(JSON.stringify({ sub: 'sc://o/p/c', iss: 'https://vstoken', aud: 'api://AzureADTokenExchange' })).toString('base64') +
+        '.s';
+
+    anyTl.getVariable = (k: string): string | undefined =>
+        ({ 'System.AccessToken': 'ado-oauth', 'Build.Repository.Name': 'my-repo' } as { [k: string]: string })[k];
+    anyTl.getEndpointAuthorizationParameter = (): string | undefined => undefined;
+    anyTl.setVariable = (k: string, v: string): void => {
+        outputs[k] = v;
+    };
+    anyHttp.HttpClient = class {
+        async post(url: string, data: string): Promise<{ message: { statusCode: number }; readBody: () => Promise<string> }> {
+            postCalls.push({ url, body: JSON.parse(data) });
+            if (url.indexOf('/oidctoken') !== -1) {
+                return { message: { statusCode: 200 }, readBody: async (): Promise<string> => JSON.stringify({ oidcToken: adoToken }) };
+            }
+            return { message: { statusCode: exchangeStatus }, readBody: async (): Promise<string> => exchangeBody };
+        }
+    };
+
+    return {
+        postCalls,
+        outputs,
+        adoToken,
+        restore: (): void => {
+            anyTl.getVariable = savedGetVariable;
+            anyTl.getEndpointAuthorizationParameter = savedGetParam;
+            anyTl.setVariable = savedSetVariable;
+            anyHttp.HttpClient = savedHttpClient;
+        },
+    };
+}
+
 function runSyncTest(description: string, testFunc: () => void | Promise<void>, skip?: boolean): void {
     if (skip) {
         it.skip(description);

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -113,10 +113,6 @@ describe('JFrog Artifactory Extension Tests', (): void => {
         runSyncTest(
             'OIDC CLI download builds a Bearer handler from the exchanged token',
             async (): Promise<void> => {
-                // Regression: JFrogToolsInstaller downloaded the CLI anonymously for OIDC
-                // service connections (createAuthHandlers returned []), causing HTTP 401.
-                // It must instead perform an OIDC token exchange and authenticate the
-                // download with the resulting access token.
                 const anyTl: any = taskLib;
                 const origGetParam: unknown = anyTl.getEndpointAuthorizationParameter;
                 const origGetUrl: unknown = anyTl.getEndpointUrl;
@@ -131,15 +127,11 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                         return params[key];
                     };
                     let exchanged: { service: string; platformUrl: string; providerName: string } | undefined;
-                    const fakeExchange: (service: string, platformUrl: string, providerName: string) => Promise<string> = async (
-                        service: string,
-                        platformUrl: string,
-                        providerName: string,
-                    ): Promise<string> => {
+                    const fakeExchange = async (service: string, platformUrl: string, providerName: string): Promise<string> => {
                         exchanged = { service, platformUrl, providerName };
                         return 'EXCHANGED_ACCESS_TOKEN';
                     };
-                    const handlers: any[] = await (jfrogUtils as any).createCliDownloadAuthHandlers('svc', fakeExchange);
+                    const handlers: any[] = await jfrogUtils.createCliDownloadAuthHandlers('svc', fakeExchange);
                     assert.strictEqual(handlers.length, 1, 'expected exactly one auth handler');
                     assert.strictEqual(handlers[0].constructor.name, 'BearerCredentialHandler', 'expected a Bearer handler');
                     assert.strictEqual(handlers[0].token, 'EXCHANGED_ACCESS_TOKEN', 'Bearer handler must carry the exchanged token');
@@ -163,7 +155,7 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                     anyTl.getEndpointAuthorizationParameter = (id: string, key: string): string | undefined =>
                         key === 'apitoken' ? 'STATIC_TOKEN' : undefined;
                     let exchanged: boolean = false;
-                    const handlers: any[] = await (jfrogUtils as any).createCliDownloadAuthHandlers(
+                    const handlers: any[] = await jfrogUtils.createCliDownloadAuthHandlers(
                         'svc',
                         async (): Promise<string> => {
                             exchanged = true;
@@ -175,6 +167,120 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                     assert.strictEqual(handlers[0].token, 'STATIC_TOKEN');
                 } finally {
                     anyTl.getEndpointAuthorizationParameter = origGetParam;
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'OIDC exchange failure surfaces a clear error, not an unhandled rejection',
+            async (): Promise<void> => {
+                const anyTl: any = taskLib;
+                const origGetParam: unknown = anyTl.getEndpointAuthorizationParameter;
+                const origGetUrl: unknown = anyTl.getEndpointUrl;
+                try {
+                    anyTl.getEndpointUrl = (): string => 'https://example.jfrog.io/artifactory';
+                    anyTl.getEndpointAuthorizationParameter = (id: string, key: string): string | undefined => {
+                        const params: { [k: string]: string } = {
+                            oidcProviderName: 'my-azure-oidc',
+                            jfrogPlatformUrl: 'https://example.jfrog.io',
+                        };
+                        return params[key];
+                    };
+                    const failingExchange = async (): Promise<string> => {
+                        throw new Error('OIDC token exchange failed: HTTP 403\nBody: {"error":"forbidden"}');
+                    };
+                    await assert.rejects(
+                        () => jfrogUtils.createCliDownloadAuthHandlers('svc', failingExchange),
+                        (err: Error) => {
+                            assert.ok(err.message.includes('OIDC token exchange failed'), 'error must mention OIDC exchange failure');
+                            assert.ok(err.message.includes('403'), 'error must include the HTTP status');
+                            return true;
+                        },
+                    );
+                } finally {
+                    anyTl.getEndpointAuthorizationParameter = origGetParam;
+                    anyTl.getEndpointUrl = origGetUrl;
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'OIDC exchange returning no access_token surfaces a clear error',
+            async (): Promise<void> => {
+                const anyTl: any = taskLib;
+                const origGetParam: unknown = anyTl.getEndpointAuthorizationParameter;
+                const origGetUrl: unknown = anyTl.getEndpointUrl;
+                try {
+                    anyTl.getEndpointUrl = (): string => 'https://example.jfrog.io/artifactory';
+                    anyTl.getEndpointAuthorizationParameter = (id: string, key: string): string | undefined => {
+                        const params: { [k: string]: string } = {
+                            oidcProviderName: 'my-azure-oidc',
+                            jfrogPlatformUrl: 'https://example.jfrog.io',
+                        };
+                        return params[key];
+                    };
+                    const emptyTokenExchange = async (): Promise<string> => {
+                        throw new Error('OIDC token exchange response did not contain an access token.');
+                    };
+                    await assert.rejects(
+                        () => jfrogUtils.createCliDownloadAuthHandlers('svc', emptyTokenExchange),
+                        (err: Error) => {
+                            assert.ok(err.message.includes('did not contain an access token'), 'error must describe the missing token');
+                            return true;
+                        },
+                    );
+                } finally {
+                    anyTl.getEndpointAuthorizationParameter = origGetParam;
+                    anyTl.getEndpointUrl = origGetUrl;
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'Cached CLI never triggers the OIDC auth-handler provider',
+            async (): Promise<void> => {
+                const anyTl: any = taskLib;
+                const origGetParam: unknown = anyTl.getEndpointAuthorizationParameter;
+                const origGetUrl: unknown = anyTl.getEndpointUrl;
+                const origFindLocalTool: unknown = (toolLib as any).findLocalTool;
+                try {
+                    anyTl.getEndpointUrl = (): string => 'https://example.jfrog.io/artifactory';
+                    anyTl.getEndpointAuthorizationParameter = (id: string, key: string): string | undefined => {
+                        const params: { [k: string]: string } = { oidcProviderName: 'my-azure-oidc' };
+                        return params[key];
+                    };
+                    // Simulate a cache hit: findLocalTool returns a directory
+                    const cachedDir: string = join(__dirname, 'testData', 'jf', '2.111.0', os.arch());
+                    (toolLib as any).findLocalTool = (): string => cachedDir;
+
+                    let providerCalled: boolean = false;
+                    const authProvider = async (): Promise<any[]> => {
+                        providerCalled = true;
+                        return [];
+                    };
+
+                    const cliPath: string = await new Promise<string>((resolve, reject) => {
+                        jfrogUtils.executeCliTask(
+                            (path: string) => {
+                                resolve(path);
+                            },
+                            '2.111.0',
+                            'https://example.jfrog.io/artifactory/repo/2.111.0/jfrog-cli-linux-amd64/jf',
+                            authProvider,
+                        );
+                        // executeCliTask catches errors and sets task result; give it time
+                        setTimeout(() => reject(new Error('executeCliTask did not invoke callback within 5s')), 5000);
+                    });
+
+                    assert.strictEqual(providerCalled, false, 'auth provider must NOT be called when CLI is cached');
+                    assert.ok(cliPath.includes('jf'), 'resolved path must contain the CLI binary name');
+                } finally {
+                    anyTl.getEndpointAuthorizationParameter = origGetParam;
+                    anyTl.getEndpointUrl = origGetUrl;
+                    (toolLib as any).findLocalTool = origFindLocalTool;
                 }
             },
             TestUtils.isSkipTest('unit'),

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -127,7 +127,7 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                         return params[key];
                     };
                     let exchanged: { service: string; platformUrl: string; providerName: string } | undefined;
-                    const fakeExchange = async (service: string, platformUrl: string, providerName: string): Promise<string> => {
+                    const fakeExchange: (s: string, p: string, o: string) => Promise<string> = async (service: string, platformUrl: string, providerName: string): Promise<string> => {
                         exchanged = { service, platformUrl, providerName };
                         return 'EXCHANGED_ACCESS_TOKEN';
                     };
@@ -187,7 +187,7 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                         };
                         return params[key];
                     };
-                    const failingExchange = async (): Promise<string> => {
+                    const failingExchange: () => Promise<string> = async (): Promise<string> => {
                         throw new Error('OIDC token exchange failed: HTTP 403\nBody: {"error":"forbidden"}');
                     };
                     await assert.rejects(
@@ -221,7 +221,7 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                         };
                         return params[key];
                     };
-                    const emptyTokenExchange = async (): Promise<string> => {
+                    const emptyTokenExchange: () => Promise<string> = async (): Promise<string> => {
                         throw new Error('OIDC token exchange response did not contain an access token.');
                     };
                     await assert.rejects(
@@ -257,7 +257,7 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                     (toolLib as any).findLocalTool = (): string => cachedDir;
 
                     let providerCalled: boolean = false;
-                    const authProvider = async (): Promise<any[]> => {
+                    const authProvider: () => Promise<any[]> = async (): Promise<any[]> => {
                         providerCalled = true;
                         return [];
                     };


### PR DESCRIPTION
## Problem

The **JFrog Tools Installer** task fails to download the JFrog CLI with **HTTP 401** when the Artifactory service connection uses **OIDC**, if the CLI is not already staged in the agent tool cache:

```
Downloading: ***artifactory/jfrog-cli-virtual/2.85.0/jfrog-cli-linux-amd64/jf
##[error]Error occurred while executing task: Failed while attempting to download JFrog CLI ...
Error: Unexpected HTTP response: 401
```

It works with access-token connections, and it works on agents where the CLI is already cached (the download is skipped entirely), which is why the failure only surfaces for OIDC + a fresh agent.

## Root cause

`JFrogToolsInstaller` built the CLI-download authentication via `createAuthHandlers()`, which only understands **static** credentials:

- `apitoken` → Bearer handler
- `username` + `password` → Basic handler
- otherwise → `[]` (anonymous)

An OIDC service connection carries none of those endpoint parameters — its credential only exists after an OIDC token exchange. So `createAuthHandlers()` returned `[]`, the CLI was downloaded **anonymously**, and a private `cliInstallationRepo` responded **401**.

The extension's existing OIDC exchange runs `jf eot`, i.e. it needs the CLI to already exist — which is a chicken-and-egg problem at install time, since the CLI is the very artifact being downloaded.

## Fix

- **`exchangeOidcTokenViaRest()`** — a CLI-independent OIDC exchange. Reuses the existing `fetchAzureOidcToken()` for the Azure DevOps ID token, then `POST`s it to JFrog Access `/access/api/v1/oidc/token` with the same request `jf eot` sends for an Azure provider (`grant_type` / `subject_token_type` / `subject_token` / `provider_name` / `provider_type=Azure` / `audience`), and returns the exchanged access token.
- **`createCliDownloadAuthHandlers()`** — routes OIDC connections through the REST exchange (Bearer of the exchanged token) and every other connection type through the existing `createAuthHandlers()` (unchanged).
- **Lazy resolution** — the Tools Installer passes a handler *provider*; `getCliPath()` only invokes it when a download is actually required, so a **cached CLI never triggers an exchange**.
- Extracted a shared `resolvePlatformUrl()` helper (dedup with the existing OIDC flow).

## Backward compatibility

The only shared code path changed is `getCliPath()` (used by all 18 tasks); it accepts an array **or** a provider function, and arrays pass through untouched. Verified behavior across scenarios:

- Existing task (no URL) → releases URL + `[]` handlers — unchanged
- Existing task, CLI cached → no download — unchanged
- Legacy array handlers + download URL → passed through unchanged
- Installer, token connection → `Bearer(apitoken)`, no exchange
- Installer, OIDC connection → `Bearer(exchanged token)` authenticates the download (the fix)
- Installer, OIDC + cached CLI → exchange never runs, no download
- Exchange failure → task fails cleanly with the error surfaced

Token, basic, anonymous, cached, custom-path, releases-fallback and the extractors flow are all unchanged. `tsc` and `eslint` are clean on the changed files.

## Tests

Adds unit tests covering the OIDC download path (Bearer built from the exchanged token) and the non-OIDC path (static credentials, no exchange).
