### PR TITLE
chore: dummy no-op PR to baseline E2E workflow (safe to close)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1513,3 +1513,5 @@ export ADO_SKIP_TESTS=nuget,dotnet
 
 Please help us improve jfrog-azure-devops-extension by [reporting issues](https://github.com/jfrog/jfrog-azure-devops-extension/issues/new/choose) you encounter.
 
+
+<!-- Dummy PR to verify E2E Sanity/OIDC jobs are diff-independent (baseline off dev). Safe to close. -->


### PR DESCRIPTION
Diagnostic-only PR. **No code changes** — a single comment appended to README.

Purpose: confirm the **"2. Sanity Tests"** and **"3. OIDC Tests"** E2E jobs fail identically on a PR branched straight off `dev`, with none of the RTECO-1402 changes. This proves those two failures are the workflow's install-gated ADO trigger (missing `JFrog*E2E` tasks), not caused by PR #638.

Safe to close once observed.