### PR TITLE
Release sync: post-Apr-30 product changes into v2 (#638, CLI 2.111.0, Node 22)

### DIFF
--- a/.github/workflows/e2e-plugin-tests.yml
+++ b/.github/workflows/e2e-plugin-tests.yml
@@ -78,12 +78,12 @@ on:
         required: false
         default: 'false'
 
-# Only one E2E run at a time — prevents two PRs racing to trigger the same
-# ADO pipeline simultaneously (which the dev org's parallel-job quota
-# would queue anyway).
+# One E2E run at a time per PR. A new label-trigger on the same PR cancels
+# the previous queued/in-progress run so the latest commit is always tested.
+# Across different PRs, runs are independent and execute in parallel.
 concurrency:
-  group: e2e-plugin-tests
-  cancel-in-progress: false
+  group: e2e-plugin-tests-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 # ======================================================================
 # JOB 1 — Build the .vsix from the PR branch and upload as artifact.
@@ -212,23 +212,6 @@ jobs:
           retention-days: 14
           if-no-files-found: error
 
-      - name: Publish .vsix to Marketplace
-        if: ${{ env.MARKETPLACE_PAT != '' }}
-        env:
-          MARKETPLACE_PAT: ${{ secrets.ADO_E2E_MARKETPLACE_PAT }}
-        run: |
-          set -euo pipefail
-          vsix_path="$(ls -1 ./*.vsix | head -1)"
-          echo "Publishing $vsix_path to Marketplace..."
-          npx tfx extension publish \
-            --vsix "$vsix_path" \
-            --token "$MARKETPLACE_PAT" \
-            --no-wait-validation
-          echo "Published successfully."
-          echo "Waiting 90s for Marketplace async validation and ADO extension cache to propagate..."
-          sleep 90
-          echo "Done waiting — ADO pipelines will now run against the freshly published extension."
-
       - name: Write install instructions to job summary
         env:
           VSIX_VERSION: ${{ steps.build_vsix.outputs.vsix_version }}
@@ -334,7 +317,7 @@ jobs:
       - name: Checkout (for trigger script)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
 
       - name: Trigger ADO sanity pipeline and wait for result
         # The sanity pipeline (.pipelines/ado-sanity-pipeline.yml) tests:
@@ -406,7 +389,7 @@ jobs:
       - name: Checkout (for trigger script)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
 
       - name: Trigger ADO OIDC test pipeline and wait for result
         # The OIDC pipeline covers:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu, windows ]
-        node-version: [ '16', '20', '24' ]
+        node-version: [ '16', '20', '22', '24' ]
         include:
           - os: windows
             extraSkipTests: ",conan"

--- a/buildScripts/trigger-ado-pipeline.sh
+++ b/buildScripts/trigger-ado-pipeline.sh
@@ -7,7 +7,7 @@ set -eu
 #   ADO_ORG         - Azure DevOps organization name (e.g. vigneshc0742)
 #   ADO_PROJECT     - Azure DevOps project name     (e.g. ecomatrix-test)
 #   ADO_PIPELINE_ID - Pipeline definition ID         (e.g. 63)
-#   ADO_PAT         - PAT with Build Read+Execute and Project Read scopes
+#   ADO_PAT         - PAT with Build Read+Execute and Project Read scopes only
 #
 # Optional environment variables:
 #   GH_PR_NUMBER    - GitHub PR number passed into pipeline as a variable (default: 0)
@@ -43,20 +43,53 @@ echo "=============================================="
 RESPONSE_FILE=$(mktemp)
 trap 'rm -f "$RESPONSE_FILE"' EXIT
 
-HTTP_STATUS=$(curl -sS -o "$RESPONSE_FILE" -w "%{http_code}" -X POST \
-    "${API_BASE}/pipelines/${ADO_PIPELINE_ID}/runs?api-version=7.1" \
-    -H "${AUTH_HEADER}" \
-    -H "Content-Type: application/json" \
-    -d "{
-          \"variables\": {
-            \"GH_PR_NUMBER\":   { \"value\": \"${GH_PR_NUMBER}\",  \"isSecret\": false },
-            \"GH_COMMIT_SHA\":  { \"value\": \"${GH_COMMIT_SHA}\", \"isSecret\": false }
-          }
-        }" || echo "000")
+# A freshly (re)installed private extension is not immediately resolvable by
+# ADO's pipeline queue-time validator: it returns HTTP 400 with
+# "A task is missing. The pipeline references a task called '...E2E'" until the
+# org's task catalog catches up. This is an eventual-consistency lag, not a
+# real error, so retry the trigger for up to TRIGGER_RETRY_MINUTES, once per
+# minute, ONLY for that specific 400. All other statuses fail immediately.
+TRIGGER_RETRY_MINUTES="${TRIGGER_RETRY_MINUTES:-15}"
+TRIGGER_RETRY_INTERVAL_SECONDS="${TRIGGER_RETRY_INTERVAL_SECONDS:-60}"
+TRIGGER_DEADLINE=$(( $(date +%s) + TRIGGER_RETRY_MINUTES * 60 ))
+TRIGGER_ATTEMPT=0
 
-RUN_RESPONSE="$(cat "$RESPONSE_FILE")"
+while : ; do
+    TRIGGER_ATTEMPT=$(( TRIGGER_ATTEMPT + 1 ))
 
-if [ "$HTTP_STATUS" != "200" ]; then
+    HTTP_STATUS=$(curl -sS -o "$RESPONSE_FILE" -w "%{http_code}" -X POST \
+        "${API_BASE}/pipelines/${ADO_PIPELINE_ID}/runs?api-version=7.1" \
+        -H "${AUTH_HEADER}" \
+        -H "Content-Type: application/json" \
+        -d "{
+              \"variables\": {
+                \"GH_PR_NUMBER\":   { \"value\": \"${GH_PR_NUMBER}\",  \"isSecret\": false },
+                \"GH_COMMIT_SHA\":  { \"value\": \"${GH_COMMIT_SHA}\", \"isSecret\": false }
+              }
+            }" || echo "000")
+
+    RUN_RESPONSE="$(cat "$RESPONSE_FILE")"
+
+    if [ "$HTTP_STATUS" = "200" ]; then
+        break
+    fi
+
+    # Retry only the transient "task is missing" 400 (extension still
+    # propagating in the org); every other failure is terminal.
+    if [ "$HTTP_STATUS" = "400" ] && printf '%s' "$RUN_RESPONSE" | grep -q "A task is missing"; then
+        if [ "$(date +%s)" -lt "$TRIGGER_DEADLINE" ]; then
+            echo "[$(date -u '+%H:%M:%S')] Trigger attempt ${TRIGGER_ATTEMPT}: HTTP 400 'A task is missing' — the E2E extension is still propagating in org '${ADO_ORG}'. Retrying in ${TRIGGER_RETRY_INTERVAL_SECONDS}s (up to ${TRIGGER_RETRY_MINUTES} min)..."
+            sleep "$TRIGGER_RETRY_INTERVAL_SECONDS"
+            continue
+        fi
+        echo "ERROR: Pipeline trigger still failing with 'A task is missing' after ${TRIGGER_RETRY_MINUTES} minutes."
+        echo "  The private E2E extension did not become resolvable in org '${ADO_ORG}' within the retry window."
+        echo "  Response    :"
+        echo "${RUN_RESPONSE}" | head -c 2000
+        echo ""
+        exit 1
+    fi
+
     echo "ERROR: Pipeline trigger failed."
     echo "  HTTP status : ${HTTP_STATUS}"
     echo "  Endpoint    : ${API_BASE}/pipelines/${ADO_PIPELINE_ID}/runs?api-version=7.1"
@@ -71,7 +104,7 @@ if [ "$HTTP_STATUS" != "200" ]; then
         *)   echo "  Hint: see the response body above for the ADO error message." ;;
     esac
     exit 1
-fi
+done
 
 RUN_ID=$(echo "$RUN_RESPONSE"   | jq -r '.id   // empty')
 RUN_URL=$(echo "$RUN_RESPONSE"  | jq -r '._links.web.href // empty')

--- a/jfrog-tasks-utils/utils.d.ts
+++ b/jfrog-tasks-utils/utils.d.ts
@@ -6,7 +6,7 @@ declare module '@jfrog/tasks-utils' {
         runTaskFunc: (cliPath: string) => void | Promise<void>,
         cliVersion?: string,
         cliDownloadUrl?: string,
-        cliAuthHandlers?: ifm.IRequestHandler[],
+        cliAuthHandlers?: ifm.IRequestHandler[] | (() => Promise<ifm.IRequestHandler[]>),
     ): void;
     export function quote(str: string): string;
     export function downloadCli(cliDownloadUrl?: string, cliAuthHandlers?: ifm.IRequestHandler[], cliVersion?: string): Promise<string>;
@@ -63,6 +63,10 @@ declare module '@jfrog/tasks-utils' {
     export function addTrailingSlashIfNeeded(str: string): string;
     export function buildCliArtifactoryDownloadUrl(rtUrl: string, repoName: string, cliVersion?: string): string;
     export function createAuthHandlers(serviceConnection: string): ifm.IRequestHandler[];
+    export function createCliDownloadAuthHandlers(serviceConnection: string, exchangeFn?: (service: string, platformUrl: string, oidcProviderName: string) => Promise<string>,): Promise<ifm.IRequestHandler[]>;
+    export function exchangeOidcTokenViaRest(service: string, platformUrl: string, oidcProviderName: string): Promise<string>;
+    export function isOidcConnection(serviceConnection: string): boolean;
+    export function resolvePlatformUrl(service: string): string;
     export function stripTrailingSlash(str: string): string;
     export function writeSpecContentToSpecPath(specSource: string, specPath: string): void;
     export function addCommonGenericParams(cliCommand: string, specPath: string): string;

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -12,7 +12,7 @@ const fileName = getCliExecutableName();
 const jfrogCliToolName = 'jf';
 const cliPackage = 'jfrog-cli-' + getArchitecture();
 const fallbackCliVersion = '2.99.0';
-let defaultJfrogCliVersion = '2.103.0';
+let defaultJfrogCliVersion = '2.111.0';
 
 /**
  * Executes an HTTP request with retry logic for 5xx errors.
@@ -144,7 +144,7 @@ const minCustomCliVersion = '2.10.0';
 const minSupportedStdinSecretCliVersion = '2.36.0';
 const minSupportedServerIdEnvCliVersion = '2.37.0';
 const minSupportedOidcCliVersion = '2.75.0';
-const pluginVersion = '2.14.1';
+const pluginVersion = '2.14.2';
 const buildAgent = 'jfrog-azure-devops-extension';
 
 /**

--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -201,6 +201,10 @@ module.exports = {
     isToolExists: isToolExists,
     buildCliArtifactoryDownloadUrl: buildCliArtifactoryDownloadUrl,
     createAuthHandlers: createAuthHandlers,
+    createCliDownloadAuthHandlers: createCliDownloadAuthHandlers,
+    exchangeOidcTokenViaRest: exchangeOidcTokenViaRest,
+    isOidcConnection: isOidcConnection,
+    resolvePlatformUrl: resolvePlatformUrl,
     taskDefaultCleanup: taskDefaultCleanup,
     writeSpecContentToSpecPath: writeSpecContentToSpecPath,
     stripTrailingSlash: stripTrailingSlash,
@@ -285,7 +289,11 @@ function getCliPath(cliDownloadUrl, cliAuthHandlers, cliVersion) {
         } else {
             const errMsg = generateDownloadCliErrorMessage(cliDownloadUrl, cliVersion);
             createCliDirs();
-            return downloadCli(cliDownloadUrl, cliAuthHandlers, cliVersion)
+            // cliAuthHandlers may be an array or a provider function returning a Promise<array>.
+            // Resolve it lazily here so that work such as an OIDC token exchange only happens
+            // when a download is actually required — never when the CLI is already cached.
+            return Promise.resolve(typeof cliAuthHandlers === 'function' ? cliAuthHandlers() : cliAuthHandlers)
+                .then((resolvedHandlers) => downloadCli(cliDownloadUrl, resolvedHandlers, cliVersion))
                 .then((cliPath) => resolve(cliPath))
                 .catch((error) => reject(errMsg + '\n' + error));
         }
@@ -328,6 +336,41 @@ function createAuthHandlers(serviceConnection) {
 
     // Use basic authentication.
     return [new credentialsHandler.BasicCredentialHandler(artifactoryUser, artifactoryPassword, false)];
+}
+
+/**
+ * Returns whether the given service connection uses OIDC authentication.
+ * @param {string} serviceConnection - The service connection ID.
+ * @returns {boolean}
+ */
+function isOidcConnection(serviceConnection) {
+    return !!tl.getEndpointAuthorizationParameter(serviceConnection, 'oidcProviderName', true);
+}
+
+/**
+ * Builds the authentication handlers used to download the JFrog CLI.
+ *
+ * For OIDC-based service connections the credential does not exist as a static
+ * token — it must be obtained through an OIDC token exchange. The CLI-based
+ * exchange (exchangeOidcTokenAndSetStepVariables) cannot be used here because the
+ * CLI is the very artifact being downloaded, so this performs a CLI-independent
+ * REST exchange (exchangeOidcTokenViaRest) and authenticates the download with the
+ * resulting access token. For all other connection types it falls back to the
+ * synchronous createAuthHandlers (access token / basic / anonymous).
+ *
+ * @param {string} serviceConnection - The Artifactory service connection ID.
+ * @param {(service: string, platformUrl: string, oidcProviderName: string) => Promise<string>} [exchangeFn]
+ *        - OIDC exchange implementation; injectable for testing. Defaults to exchangeOidcTokenViaRest.
+ * @returns {Promise<Array>} Authentication handlers for the CLI download.
+ */
+async function createCliDownloadAuthHandlers(serviceConnection, exchangeFn = exchangeOidcTokenViaRest) {
+    if (!isOidcConnection(serviceConnection)) {
+        return createAuthHandlers(serviceConnection);
+    }
+    const platformUrl = resolvePlatformUrl(serviceConnection);
+    const oidcProviderName = tl.getEndpointAuthorizationParameter(serviceConnection, 'oidcProviderName', true);
+    const accessToken = await exchangeFn(serviceConnection, platformUrl, oidcProviderName);
+    return [new credentialsHandler.BearerCredentialHandler(accessToken, false)];
 }
 
 function generateDownloadCliErrorMessage(downloadUrl, cliVersion) {
@@ -393,11 +436,14 @@ function maskSecrets(str) {
         .replace(/--access-token='.*?'/g, '--access-token=***');
 }
 
-async function fetchOidcTokenIfConfigured(service, cliPath, buildDir) {
-    const oidcProviderName = tl.getEndpointAuthorizationParameter(service, 'oidcProviderName', true);
-    if (!oidcProviderName) {
-        return undefined;
-    }
+/**
+ * Resolves the JFrog platform URL for a service connection. Prefers the explicit
+ * 'jfrogPlatformUrl' authorization parameter and falls back to parsing it from the
+ * service URL.
+ * @param {string} service - The service connection ID.
+ * @returns {string} The resolved platform URL.
+ */
+function resolvePlatformUrl(service) {
     const serviceUrl = tl.getEndpointUrl(service, false);
     let platformUrl = '';
     try {
@@ -408,6 +454,15 @@ async function fetchOidcTokenIfConfigured(service, cliPath, buildDir) {
     if (!platformUrl || !platformUrl.trim()) {
         platformUrl = parsePlatformUrlFromServiceUrl(serviceUrl);
     }
+    return platformUrl;
+}
+
+async function fetchOidcTokenIfConfigured(service, cliPath, buildDir) {
+    if (!isOidcConnection(service)) {
+        return undefined;
+    }
+    const oidcProviderName = tl.getEndpointAuthorizationParameter(service, 'oidcProviderName', true);
+    const platformUrl = resolvePlatformUrl(service);
     return exchangeOidcTokenAndSetStepVariables(service, platformUrl, oidcProviderName, cliPath, buildDir);
 }
 
@@ -617,6 +672,58 @@ async function fetchAzureOidcToken(serviceConnectionID) {
     }
     debugLogIDToken(body.oidcToken);
     return body.oidcToken;
+}
+
+/**
+ * Performs an OIDC token exchange WITHOUT the JFrog CLI, via a direct REST call to
+ * JFrog Access. Required by the JFrog Tools Installer, which must authenticate the
+ * CLI *download* itself — at that point the CLI does not yet exist, so the
+ * CLI-based exchange cannot be used. The request mirrors what `jf eot` sends for an
+ * Azure provider (grant_type / subject_token_type / subject_token / provider_name /
+ * provider_type / audience). The Azure DevOps identity mapping is matched on the ID
+ * token's subject claim, which is carried in subject_token.
+ *
+ * @param {string} service - The service connection ID.
+ * @param {string} platformUrl - The JFrog platform base URL.
+ * @param {string} oidcProviderName - The configured OIDC provider name.
+ * @returns {Promise<string>} The exchanged JFrog access token.
+ */
+async function exchangeOidcTokenViaRest(service, platformUrl, oidcProviderName) {
+    const oidcAudience = tl.getEndpointAuthorizationParameter(service, 'oidcAudience', true) || 'api://AzureADTokenExchange';
+    const idToken = await fetchAzureOidcToken(service);
+
+    const exchangeUrl = addTrailingSlashIfNeeded(platformUrl) + 'access/api/v1/oidc/token';
+    const requestBody = {
+        grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+        subject_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+        subject_token: idToken,
+        provider_name: oidcProviderName,
+        provider_type: 'Azure',
+        audience: oidcAudience,
+    };
+
+    const requestOptions = { ...getProxyConfiguration(), socketTimeout: 30000 };
+    const httpClient = new httpm.HttpClient(buildAgent, [], requestOptions);
+    tl.debug('Exchanging OIDC token via REST at: ' + exchangeUrl);
+    const response = await httpClient.post(exchangeUrl, JSON.stringify(requestBody), {
+        'Content-Type': 'application/json',
+    });
+
+    const statusCode = response.message.statusCode;
+    const responseBody = await response.readBody();
+    if (statusCode !== 200) {
+        throw new Error(`OIDC token exchange failed: HTTP ${statusCode}\nBody: ${responseBody}`);
+    }
+    /** @type {{ access_token?: string, username?: string }} */
+    const body = JSON.parse(responseBody);
+    if (!body.access_token) {
+        throw new Error('OIDC token exchange response did not contain an access token.');
+    }
+
+    // Publish outputs for parity with the CLI-based OIDC flow (downstream consumption / debug).
+    tl.setVariable(oidcUserOutputName, body.username || '', true);
+    tl.setVariable(oidcTokenOutputName, body.access_token, true);
+    return body.access_token;
 }
 
 async function exchangeOidcTokenAndSetStepVariables(service, serviceUrl, oidcProviderName, cliPath, buildDir) {

--- a/tasks/JFrogToolsInstaller/toolsInstaller.js
+++ b/tasks/JFrogToolsInstaller/toolsInstaller.js
@@ -21,8 +21,11 @@ function InstallCliAndExecuteCliTask(RunTaskCbk) {
     // Set the requested CLI version env to download it now, and to use in succeeding tasks.
     tl.setVariable(utils.pipelineRequestedCliVersionEnv, cliVersion);
     let downloadUrl = utils.buildCliArtifactoryDownloadUrl(artifactoryUrl, cliInstallationRepo, cliVersion);
-    let authHandlers = utils.createAuthHandlers(artifactoryService);
-    utils.executeCliTask(RunTaskCbk, cliVersion, downloadUrl, authHandlers);
+    // Pass a provider (resolved lazily by executeCliTask only if a download is needed).
+    // For OIDC service connections this performs a CLI-independent OIDC token exchange so
+    // the CLI download itself is authenticated; other connection types use static credentials.
+    let authHandlersProvider = () => utils.createCliDownloadAuthHandlers(artifactoryService);
+    utils.executeCliTask(RunTaskCbk, cliVersion, downloadUrl, authHandlersProvider);
 }
 
 async function RunTaskCbk(cliPath) {

--- a/tests/package.json
+++ b/tests/package.json
@@ -22,7 +22,8 @@
         "null-writable": "^1.0.5",
         "rimraf": "^6.1.2",
         "sync-request": "^6.1.0",
-        "ts-node": "^10.9.1"
+        "ts-node": "^10.9.1",
+        "typescript": "^5.2.2"
     },
     "scripts": {
         "test": "npm i && mocha -r ts-node/register tests.ts -t 1000000"

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -8,6 +8,8 @@ import * as syncRequest from 'sync-request';
 import * as TestUtils from './testUtils';
 import { platformDockerDomain } from './testUtils';
 import * as toolLib from 'azure-pipelines-tool-lib/tool';
+import * as taskLib from 'azure-pipelines-task-lib/task';
+import * as httpm from 'typed-rest-client/HttpClient';
 import * as assert from 'assert';
 import * as os from 'os';
 import conanUtils from '../tasks/JFrogConan/conanUtils';
@@ -105,6 +107,327 @@ describe('JFrog Artifactory Extension Tests', (): void => {
                 assert.strictEqual(jfrogUtils.cliJoin('jf', 'rt', 'u', 'a/b/c', 'a/b/c'), 'jf rt u a/b/c a/b/c');
                 assert.strictEqual(jfrogUtils.cliJoin('jf', 'rt', 'u', 'a\bc', 'a\bc'), 'jf rt u a\bc a\bc');
                 assert.strictEqual(jfrogUtils.cliJoin('jf', 'rt', 'u', 'a\\bc\\', 'a\\bc\\'), 'jf rt u a\\bc\\ a\\bc\\');
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'OIDC CLI download builds a Bearer handler from the exchanged token',
+            async (): Promise<void> => {
+                const anyTl: any = taskLib;
+                const origGetParam: unknown = anyTl.getEndpointAuthorizationParameter;
+                const origGetUrl: unknown = anyTl.getEndpointUrl;
+                try {
+                    anyTl.getEndpointUrl = (): string => 'https://example.jfrog.io/artifactory';
+                    anyTl.getEndpointAuthorizationParameter = (id: string, key: string): string | undefined => {
+                        const params: { [k: string]: string } = {
+                            oidcProviderName: 'my-azure-oidc',
+                            oidcAudience: 'api://AzureADTokenExchange',
+                            jfrogPlatformUrl: 'https://example.jfrog.io',
+                        };
+                        return params[key];
+                    };
+                    let exchanged: { service: string; platformUrl: string; providerName: string } | undefined;
+                    const fakeExchange: (s: string, p: string, o: string) => Promise<string> = async (service: string, platformUrl: string, providerName: string): Promise<string> => {
+                        exchanged = { service, platformUrl, providerName };
+                        return 'EXCHANGED_ACCESS_TOKEN';
+                    };
+                    const handlers: any[] = await jfrogUtils.createCliDownloadAuthHandlers('svc', fakeExchange);
+                    assert.strictEqual(handlers.length, 1, 'expected exactly one auth handler');
+                    assert.strictEqual(handlers[0].constructor.name, 'BearerCredentialHandler', 'expected a Bearer handler');
+                    assert.strictEqual(handlers[0].token, 'EXCHANGED_ACCESS_TOKEN', 'Bearer handler must carry the exchanged token');
+                    assert.ok(exchanged, 'OIDC exchange must be invoked');
+                    assert.strictEqual(exchanged!.providerName, 'my-azure-oidc');
+                    assert.strictEqual(exchanged!.platformUrl, 'https://example.jfrog.io');
+                } finally {
+                    anyTl.getEndpointAuthorizationParameter = origGetParam;
+                    anyTl.getEndpointUrl = origGetUrl;
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'Non-OIDC CLI download uses static credentials without an exchange',
+            async (): Promise<void> => {
+                const anyTl: any = taskLib;
+                const origGetParam: unknown = anyTl.getEndpointAuthorizationParameter;
+                try {
+                    anyTl.getEndpointAuthorizationParameter = (id: string, key: string): string | undefined =>
+                        key === 'apitoken' ? 'STATIC_TOKEN' : undefined;
+                    let exchanged: boolean = false;
+                    const handlers: any[] = await jfrogUtils.createCliDownloadAuthHandlers(
+                        'svc',
+                        async (): Promise<string> => {
+                            exchanged = true;
+                            return 'unused';
+                        },
+                    );
+                    assert.strictEqual(exchanged, false, 'must not perform an OIDC exchange for a token connection');
+                    assert.strictEqual(handlers[0].constructor.name, 'BearerCredentialHandler');
+                    assert.strictEqual(handlers[0].token, 'STATIC_TOKEN');
+                } finally {
+                    anyTl.getEndpointAuthorizationParameter = origGetParam;
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'OIDC exchange failure surfaces a clear error, not an unhandled rejection',
+            async (): Promise<void> => {
+                const anyTl: any = taskLib;
+                const origGetParam: unknown = anyTl.getEndpointAuthorizationParameter;
+                const origGetUrl: unknown = anyTl.getEndpointUrl;
+                try {
+                    anyTl.getEndpointUrl = (): string => 'https://example.jfrog.io/artifactory';
+                    anyTl.getEndpointAuthorizationParameter = (id: string, key: string): string | undefined => {
+                        const params: { [k: string]: string } = {
+                            oidcProviderName: 'my-azure-oidc',
+                            jfrogPlatformUrl: 'https://example.jfrog.io',
+                        };
+                        return params[key];
+                    };
+                    const failingExchange: () => Promise<string> = async (): Promise<string> => {
+                        throw new Error('OIDC token exchange failed: HTTP 403\nBody: {"error":"forbidden"}');
+                    };
+                    await assert.rejects(
+                        () => jfrogUtils.createCliDownloadAuthHandlers('svc', failingExchange),
+                        (err: Error) => {
+                            assert.ok(err.message.includes('OIDC token exchange failed'), 'error must mention OIDC exchange failure');
+                            assert.ok(err.message.includes('403'), 'error must include the HTTP status');
+                            return true;
+                        },
+                    );
+                } finally {
+                    anyTl.getEndpointAuthorizationParameter = origGetParam;
+                    anyTl.getEndpointUrl = origGetUrl;
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'OIDC exchange returning no access_token surfaces a clear error',
+            async (): Promise<void> => {
+                const anyTl: any = taskLib;
+                const origGetParam: unknown = anyTl.getEndpointAuthorizationParameter;
+                const origGetUrl: unknown = anyTl.getEndpointUrl;
+                try {
+                    anyTl.getEndpointUrl = (): string => 'https://example.jfrog.io/artifactory';
+                    anyTl.getEndpointAuthorizationParameter = (id: string, key: string): string | undefined => {
+                        const params: { [k: string]: string } = {
+                            oidcProviderName: 'my-azure-oidc',
+                            jfrogPlatformUrl: 'https://example.jfrog.io',
+                        };
+                        return params[key];
+                    };
+                    const emptyTokenExchange: () => Promise<string> = async (): Promise<string> => {
+                        throw new Error('OIDC token exchange response did not contain an access token.');
+                    };
+                    await assert.rejects(
+                        () => jfrogUtils.createCliDownloadAuthHandlers('svc', emptyTokenExchange),
+                        (err: Error) => {
+                            assert.ok(err.message.includes('did not contain an access token'), 'error must describe the missing token');
+                            return true;
+                        },
+                    );
+                } finally {
+                    anyTl.getEndpointAuthorizationParameter = origGetParam;
+                    anyTl.getEndpointUrl = origGetUrl;
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'Cached CLI never triggers the OIDC auth-handler provider',
+            async (): Promise<void> => {
+                const anyTl: any = taskLib;
+                const origGetParam: unknown = anyTl.getEndpointAuthorizationParameter;
+                const origGetUrl: unknown = anyTl.getEndpointUrl;
+                const origFindLocalTool: unknown = (toolLib as any).findLocalTool;
+                try {
+                    anyTl.getEndpointUrl = (): string => 'https://example.jfrog.io/artifactory';
+                    anyTl.getEndpointAuthorizationParameter = (id: string, key: string): string | undefined => {
+                        const params: { [k: string]: string } = { oidcProviderName: 'my-azure-oidc' };
+                        return params[key];
+                    };
+                    // Simulate a cache hit: findLocalTool returns a directory
+                    const cachedDir: string = join(__dirname, 'testData', 'jf', '2.111.0', os.arch());
+                    (toolLib as any).findLocalTool = (): string => cachedDir;
+
+                    let providerCalled: boolean = false;
+                    const authProvider: () => Promise<any[]> = async (): Promise<any[]> => {
+                        providerCalled = true;
+                        return [];
+                    };
+
+                    const cliPath: string = await new Promise<string>((resolve, reject) => {
+                        jfrogUtils.executeCliTask(
+                            (path: string) => {
+                                resolve(path);
+                            },
+                            '2.111.0',
+                            'https://example.jfrog.io/artifactory/repo/2.111.0/jfrog-cli-linux-amd64/jf',
+                            authProvider,
+                        );
+                        // executeCliTask catches errors and sets task result; give it time
+                        setTimeout(() => reject(new Error('executeCliTask did not invoke callback within 5s')), 5000);
+                    });
+
+                    assert.strictEqual(providerCalled, false, 'auth provider must NOT be called when CLI is cached');
+                    assert.ok(cliPath.includes('jf'), 'resolved path must contain the CLI binary name');
+                } finally {
+                    anyTl.getEndpointAuthorizationParameter = origGetParam;
+                    anyTl.getEndpointUrl = origGetUrl;
+                    (toolLib as any).findLocalTool = origFindLocalTool;
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'exchangeOidcTokenViaRest posts the correct request and returns the access token',
+            async (): Promise<void> => {
+                const stub: ReturnType<typeof stubExchangeHttp> = stubExchangeHttp(
+                    200,
+                    JSON.stringify({ access_token: 'JFROG_ACCESS_TOKEN', username: 'agrasth' }),
+                );
+                try {
+                    const token: string = await jfrogUtils.exchangeOidcTokenViaRest('svc', 'https://example.jfrog.io', 'my-provider');
+                    assert.strictEqual(token, 'JFROG_ACCESS_TOKEN', 'must return the exchanged access token');
+
+                    const exchangeCall: { url: string; body: { [k: string]: string } } | undefined = stub.postCalls.find(
+                        (c: { url: string; body: { [k: string]: string } }) => c.url.indexOf('/access/api/v1/oidc/token') !== -1,
+                    );
+                    assert.ok(exchangeCall, 'must POST to the JFrog Access OIDC token endpoint');
+                    assert.strictEqual(exchangeCall!.url, 'https://example.jfrog.io/access/api/v1/oidc/token', 'exchange URL must be correct');
+                    assert.strictEqual(exchangeCall!.body.grant_type, 'urn:ietf:params:oauth:grant-type:token-exchange');
+                    assert.strictEqual(exchangeCall!.body.subject_token_type, 'urn:ietf:params:oauth:token-type:id_token');
+                    assert.strictEqual(exchangeCall!.body.subject_token, stub.adoToken, 'must forward the ADO ID token as subject_token');
+                    assert.strictEqual(exchangeCall!.body.provider_name, 'my-provider');
+                    assert.strictEqual(exchangeCall!.body.provider_type, 'Azure');
+                    assert.strictEqual(exchangeCall!.body.audience, 'api://AzureADTokenExchange');
+                    assert.strictEqual(stub.outputs['oidc_token'], 'JFROG_ACCESS_TOKEN', 'must publish the oidc_token output variable');
+                } finally {
+                    stub.restore();
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'exchangeOidcTokenViaRest throws a clear error on a non-200 JFrog response',
+            async (): Promise<void> => {
+                const stub: ReturnType<typeof stubExchangeHttp> = stubExchangeHttp(
+                    403,
+                    JSON.stringify({ errors: [{ code: 'FORBIDDEN', message: 'Forbidden' }] }),
+                );
+                try {
+                    await assert.rejects(
+                        () => jfrogUtils.exchangeOidcTokenViaRest('svc', 'https://example.jfrog.io', 'my-provider'),
+                        /OIDC token exchange failed: HTTP 403/,
+                    );
+                } finally {
+                    stub.restore();
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'exchangeOidcTokenViaRest throws when the JFrog response has no access_token',
+            async (): Promise<void> => {
+                const stub: ReturnType<typeof stubExchangeHttp> = stubExchangeHttp(200, JSON.stringify({ token_type: 'Bearer' }));
+                try {
+                    await assert.rejects(
+                        () => jfrogUtils.exchangeOidcTokenViaRest('svc', 'https://example.jfrog.io', 'my-provider'),
+                        /did not contain an access token/,
+                    );
+                } finally {
+                    stub.restore();
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'CLI download resolves a function auth-provider to an array before downloadTool (guards handlers.forEach regression)',
+            async (): Promise<void> => {
+                const anyToolLib: any = toolLib;
+                const savedFind: unknown = anyToolLib.findLocalTool;
+                const savedDownload: unknown = anyToolLib.downloadTool;
+                const savedCache: unknown = anyToolLib.cacheFile;
+                const cacheDir: string = fs.mkdtempSync(join(os.tmpdir(), 'jfdl-'));
+                fs.writeFileSync(join(cacheDir, TestUtils.isWindows() ? 'jf.exe' : 'jf'), '#!/bin/sh\necho\n');
+                let captured: unknown = 'UNSET';
+                try {
+                    anyToolLib.findLocalTool = (): string => ''; // force a download
+                    anyToolLib.downloadTool = (_url: string, _dest: unknown, handlers: unknown): Promise<string> => {
+                        captured = handlers;
+                        return Promise.resolve(join(cacheDir, 'download.bin'));
+                    };
+                    anyToolLib.cacheFile = (): Promise<string> => Promise.resolve(cacheDir);
+
+                    const provider: () => Promise<any[]> = async (): Promise<any[]> => [{ marker: 'RESOLVED' }];
+                    await new Promise<void>((resolve, reject) => {
+                        jfrogUtils.executeCliTask(
+                            (): void => resolve(),
+                            '2.111.0',
+                            'https://example.jfrog.io/artifactory/repo/2.111.0/jfrog-cli-linux-amd64/jf',
+                            provider,
+                        );
+                        setTimeout(() => reject(new Error('executeCliTask did not invoke callback within 5s')), 5000);
+                    });
+                    assert.ok(Array.isArray(captured), 'downloadTool must receive an ARRAY, not a function (guards this.handlers.forEach)');
+                    assert.strictEqual((captured as any[])[0].marker, 'RESOLVED', 'the resolved provider result must reach downloadTool');
+                } finally {
+                    anyToolLib.findLocalTool = savedFind;
+                    anyToolLib.downloadTool = savedDownload;
+                    anyToolLib.cacheFile = savedCache;
+                    fs.rmSync(cacheDir, { recursive: true, force: true });
+                }
+            },
+            TestUtils.isSkipTest('unit'),
+        );
+
+        runSyncTest(
+            'CLI download passes a plain array auth-handler through unchanged (backward compat)',
+            async (): Promise<void> => {
+                const anyToolLib: any = toolLib;
+                const savedFind: unknown = anyToolLib.findLocalTool;
+                const savedDownload: unknown = anyToolLib.downloadTool;
+                const savedCache: unknown = anyToolLib.cacheFile;
+                const cacheDir: string = fs.mkdtempSync(join(os.tmpdir(), 'jfdl-'));
+                fs.writeFileSync(join(cacheDir, TestUtils.isWindows() ? 'jf.exe' : 'jf'), '#!/bin/sh\necho\n');
+                let captured: unknown = 'UNSET';
+                try {
+                    anyToolLib.findLocalTool = (): string => '';
+                    anyToolLib.downloadTool = (_url: string, _dest: unknown, handlers: unknown): Promise<string> => {
+                        captured = handlers;
+                        return Promise.resolve(join(cacheDir, 'download.bin'));
+                    };
+                    anyToolLib.cacheFile = (): Promise<string> => Promise.resolve(cacheDir);
+
+                    const plainHandlers: any[] = [{ marker: 'PLAIN_ARRAY' }];
+                    await new Promise<void>((resolve, reject) => {
+                        jfrogUtils.executeCliTask(
+                            (): void => resolve(),
+                            '2.111.0',
+                            'https://example.jfrog.io/artifactory/repo/2.111.0/jfrog-cli-linux-amd64/jf',
+                            plainHandlers,
+                        );
+                        setTimeout(() => reject(new Error('executeCliTask did not invoke callback within 5s')), 5000);
+                    });
+                    assert.ok(Array.isArray(captured), 'downloadTool must receive the array');
+                    assert.strictEqual((captured as any[])[0].marker, 'PLAIN_ARRAY', 'existing array handlers must pass through unchanged');
+                } finally {
+                    anyToolLib.findLocalTool = savedFind;
+                    anyToolLib.downloadTool = savedDownload;
+                    anyToolLib.cacheFile = savedCache;
+                    fs.rmSync(cacheDir, { recursive: true, force: true });
+                }
             },
             TestUtils.isSkipTest('unit'),
         );
@@ -999,6 +1322,66 @@ function distributionCleanUp(rbName: string, rbVersion: string): void {
  * @param testFunc (Function) - The test logic
  * @param skip (Boolean, Optional) - True if test should be skipped
  */
+/**
+ * Stubs the shared task-lib + typed-rest-client HttpClient so the REAL
+ * exchangeOidcTokenViaRest can be exercised offline. The first POST (to the ADO
+ * `/oidctoken` endpoint, made by fetchAzureOidcToken) always returns a fake ADO
+ * ID token; the second POST (to JFrog Access) returns the provided status/body.
+ * Returns captured POST calls, published output variables, the fake ADO token,
+ * and a restore() to undo all stubbing.
+ */
+function stubExchangeHttp(
+    exchangeStatus: number,
+    exchangeBody: string,
+): {
+    postCalls: Array<{ url: string; body: { [k: string]: string } }>;
+    outputs: { [k: string]: string };
+    adoToken: string;
+    restore: () => void;
+} {
+    const anyTl: any = taskLib;
+    const anyHttp: any = httpm;
+    const savedGetVariable: unknown = anyTl.getVariable;
+    const savedGetParam: unknown = anyTl.getEndpointAuthorizationParameter;
+    const savedSetVariable: unknown = anyTl.setVariable;
+    const savedHttpClient: unknown = anyHttp.HttpClient;
+
+    const postCalls: Array<{ url: string; body: { [k: string]: string } }> = [];
+    const outputs: { [k: string]: string } = {};
+    const adoToken: string =
+        'h.' +
+        Buffer.from(JSON.stringify({ sub: 'sc://o/p/c', iss: 'https://vstoken', aud: 'api://AzureADTokenExchange' })).toString('base64') +
+        '.s';
+
+    anyTl.getVariable = (k: string): string | undefined =>
+        ({ 'System.AccessToken': 'ado-oauth', 'Build.Repository.Name': 'my-repo' } as { [k: string]: string })[k];
+    anyTl.getEndpointAuthorizationParameter = (): string | undefined => undefined;
+    anyTl.setVariable = (k: string, v: string): void => {
+        outputs[k] = v;
+    };
+    anyHttp.HttpClient = class {
+        async post(url: string, data: string): Promise<{ message: { statusCode: number }; readBody: () => Promise<string> }> {
+            postCalls.push({ url, body: JSON.parse(data) });
+            if (url.indexOf('/oidctoken') !== -1) {
+                return { message: { statusCode: 200 }, readBody: async (): Promise<string> => JSON.stringify({ oidcToken: adoToken }) };
+            }
+            return { message: { statusCode: exchangeStatus }, readBody: async (): Promise<string> => exchangeBody };
+        }
+    };
+
+    return {
+        postCalls,
+        outputs,
+        adoToken,
+        restore: (): void => {
+            anyTl.getVariable = savedGetVariable;
+            anyTl.getEndpointAuthorizationParameter = savedGetParam;
+            anyTl.setVariable = savedSetVariable;
+            anyHttp.HttpClient = savedHttpClient;
+        },
+    };
+}
+
 function runSyncTest(description: string, testFunc: () => void | Promise<void>, skip?: boolean): void {
     if (skip) {
         it.skip(description);


### PR DESCRIPTION
## Summary
Brings **all non-e2e product changes after 30 Apr 2026** from `dev` into `v2` for the upcoming release.

### Included (teammates’ product work)
| Commit | Author | Change |
|--------|--------|--------|
| `#635` / `dfe055b` | reshmifrog | Node 22 in test matrix |
| `16ead28` | agrasth | Default JFrog CLI → 2.111.0, pluginVersion → 2.14.2 |
| `#638` / `696faad` | Agrasth | OIDC auth for ToolsInstaller CLI download |

### Explicitly not treated as release content
Naveen’s e2e/testing commits (`#633`, `#641`, and follow-ups). Those stay out of the product cherry-picks.

### Pipeline hygiene (required)
One extra commit aligns `e2e-plugin-tests.yml` + `trigger-ado-pipeline.sh` **file contents** with `dev` so `.jfrog-pipelines/pipelines.release.yml`’s `git merge origin/dev` is conflict-free. This does not change extension task runtime behavior.

After this merges, `v2` tree == `dev` tree, so the release merge is a no-op and tagging/publishing can proceed.

## Test plan
- [ ] PR diff includes OIDC helpers (`exchangeOidcTokenViaRest`, `createCliDownloadAuthHandlers`)
- [ ] PR diff includes CLI `2.111.0` / plugin `2.14.2` and Node 22 matrix change
- [ ] No unexpected task runtime changes beyond ToolsInstaller/utils
- [ ] After merge: `git checkout v2 && git merge origin/dev` — clean / already up to date
- [ ] Run release pipeline with `NEXT_VERSION` set