### PR TITLE
feat(e2e): re-enable automated Marketplace publish + auto-update

### DIFF
--- a/.github/workflows/e2e-plugin-tests.yml
+++ b/.github/workflows/e2e-plugin-tests.yml
@@ -62,6 +62,11 @@ on:
   # Run automatically when a PR receives the "safe to test" label.
   pull_request_target:
     types: [labeled]
+  # Run automatically when code lands on v2 — i.e. a PR is merged into v2 or
+  # something is pushed to it directly — so the release branch is validated
+  # post-merge (build + publish + sanity + OIDC against the merged code).
+  push:
+    branches: [v2]
   # Allow manual triggering from the Actions UI for debugging.
   workflow_dispatch:
     inputs:
@@ -94,7 +99,8 @@ jobs:
     name: '1. Build .vsix'
     if: |
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/e2e-plugin-tests.yml
+++ b/.github/workflows/e2e-plugin-tests.yml
@@ -154,20 +154,60 @@ jobs:
           print(f"Rewrote {len(paths)} task GUIDs and names.")
           PYEOF
 
+      - name: Resolve next extension version
+        id: version
+        # Marketplace requires each publish of a (publisher, extension-id) to
+        # use a version strictly greater than the currently published one, and
+        # ADO only auto-updates to a higher version.
+        #
+        # Preferred (traceable) version is 0.<PR#>.<run_number>. But this e2e
+        # extension is shared across all runs and already has older publishes
+        # (e.g. 0.647.87), so a low PR/run can be <= what's live and get
+        # rejected. Strategy:
+        #   • candidate = 0.<PR#>.<run_number>
+        #   • query the version currently live on Marketplace
+        #   • if candidate  >  live  → publish candidate (keeps traceability)
+        #   • if candidate <= live   → take live and bump its patch (+1)
+        # When no Marketplace PAT is available we can't query, so we just emit
+        # the candidate (the publish step is skipped in that case anyway).
+        env:
+          MARKETPLACE_PAT: ${{ secrets.ADO_E2E_MARKETPLACE_PAT }}
+          PUBLISHER: "${{ secrets.ADO_E2E_PUBLISHER_ORG || secrets.ADO_E2E_ORG }}-private"
+          EXTENSION_ID: "${{ secrets.ADO_E2E_EXTENSION_ID || 'jfrog-azure-devops-extension-e2etest' }}"
+          PR_NUMBER: ${{ github.event.pull_request.number || 0 }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          set -euo pipefail
+          export CANDIDATE="0.${PR_NUMBER}.${RUN_NUMBER}"
+          export LIVE="0.0.0"
+          if [ -n "${MARKETPLACE_PAT:-}" ]; then
+            TFX_OUT=$(npx --yes tfx-cli extension show --publisher "$PUBLISHER" --extension-id "$EXTENSION_ID" --token "$MARKETPLACE_PAT" 2>&1 || true)
+            LIVE=$(echo "$TFX_OUT" | python3 -c "import sys,json; raw=sys.stdin.read(); s=raw.find('{'); d=json.loads(raw[s:]) if s>=0 else {}; v=d.get('versions',[]); print(v[0]['version'] if v else '0.0.0')" 2>/dev/null || echo '0.0.0')
+            [ -z "$LIVE" ] && LIVE='0.0.0'
+            export LIVE
+          fi
+          echo "Live version on Marketplace : $LIVE"
+          echo "Candidate (0.PR.run)        : $CANDIDATE"
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import os
+          def parse(v):
+              parts = (str(v).split('.') + ['0', '0', '0'])[:3]
+              return [int(p) if p.isdigit() else 0 for p in parts]
+          cand = os.environ['CANDIDATE']
+          live = os.environ['LIVE']
+          c, l = parse(cand), parse(live)
+          final = cand if c > l else f"{l[0]}.{l[1]}.{l[2] + 1}"
+          print(f"vsix_version={final}")
+          PY
+          echo "Resolved version written to job output."
+
       - name: Package .vsix
         id: build_vsix
         env:
-          # Version must be strictly increasing for a single (publisher,
-          # extension-id) — Marketplace rejects re-publishing an equal/lower
-          # version, and ADO only auto-updates to a higher one. Since this
-          # extension id is shared across every E2E run/PR, a PR-number-based
-          # version would go backwards when an older PR runs after a newer one.
-          # github.run_number is globally monotonic per workflow, and
-          # github.run_attempt increments on "Re-run", so
-          # 0.<run_number>.<run_attempt> is always increasing — no collisions
-          # on re-runs (the exact bug that got auto-publish removed before).
-          # The PR number is still surfaced in the artifact name + job summary.
-          VSIX_VERSION: "0.${{ github.run_number }}.${{ github.run_attempt }}"
+          # Version resolved above: preferred 0.<PR#>.<run_number>, or a
+          # patch-bump of the live Marketplace version when that would
+          # otherwise be <= what's already published.
+          VSIX_VERSION: ${{ steps.version.outputs.vsix_version }}
           # Bake the real destination publisher into the .vsix at build time.
           # Marketplace rejects uploads if the manifest publisher and the
           # destination publisher don't match exactly, so we cannot use a

--- a/.github/workflows/e2e-plugin-tests.yml
+++ b/.github/workflows/e2e-plugin-tests.yml
@@ -157,9 +157,17 @@ jobs:
       - name: Package .vsix
         id: build_vsix
         env:
-          # Traceable version so we can correlate the installed extension
-          # back to this exact PR run.
-          VSIX_VERSION: "0.${{ github.event.pull_request.number || 0 }}.${{ github.run_number }}"
+          # Version must be strictly increasing for a single (publisher,
+          # extension-id) — Marketplace rejects re-publishing an equal/lower
+          # version, and ADO only auto-updates to a higher one. Since this
+          # extension id is shared across every E2E run/PR, a PR-number-based
+          # version would go backwards when an older PR runs after a newer one.
+          # github.run_number is globally monotonic per workflow, and
+          # github.run_attempt increments on "Re-run", so
+          # 0.<run_number>.<run_attempt> is always increasing — no collisions
+          # on re-runs (the exact bug that got auto-publish removed before).
+          # The PR number is still surfaced in the artifact name + job summary.
+          VSIX_VERSION: "0.${{ github.run_number }}.${{ github.run_attempt }}"
           # Bake the real destination publisher into the .vsix at build time.
           # Marketplace rejects uploads if the manifest publisher and the
           # destination publisher don't match exactly, so we cannot use a
@@ -212,6 +220,59 @@ jobs:
           retention-days: 14
           if-no-files-found: error
 
+      - name: Publish to Marketplace, share and install (auto-update the dev org)
+        # Fully automates what used to be the manual UI step: publish the
+        # freshly built .vsix to the private publisher, share it with the dev
+        # org, and ensure it is installed there. Once installed, ADO
+        # auto-updates the org to each new version on subsequent runs, so
+        # jobs 2 & 3 exercise THIS PR's code.
+        #
+        # Gated on ADO_E2E_MARKETPLACE_PAT: if the secret is absent the step
+        # is a no-op and the manual artifact-upload flow (below) still works.
+        # The version scheme (0.<run_number>.<run_attempt>) guarantees a
+        # strictly increasing version, so re-runs never hit the old
+        # "version must increase" failure.
+        env:
+          MARKETPLACE_PAT: ${{ secrets.ADO_E2E_MARKETPLACE_PAT }}
+          ADO_ORG: ${{ secrets.ADO_E2E_ORG }}
+          PUBLISHER: "${{ secrets.ADO_E2E_PUBLISHER_ORG || secrets.ADO_E2E_ORG }}-private"
+          EXTENSION_ID: ${{ steps.build_vsix.outputs.extension_id }}
+          VSIX_VERSION: ${{ steps.build_vsix.outputs.vsix_version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MARKETPLACE_PAT:-}" ]; then
+            echo "ADO_E2E_MARKETPLACE_PAT not set — skipping auto-publish."
+            echo "The .vsix is available as a workflow artifact for manual upload."
+            exit 0
+          fi
+
+          vsix_path="$(ls -1 ./*.vsix | head -1)"
+          echo "Publishing $vsix_path (version $VSIX_VERSION) to publisher '$PUBLISHER' and sharing with org '$ADO_ORG'..."
+          npx tfx extension publish \
+            --vsix "$vsix_path" \
+            --token "$MARKETPLACE_PAT" \
+            --share-with "$ADO_ORG" \
+            --no-wait-validation
+          echo "Published and shared."
+
+          # Ensure the extension is installed in the org so ADO auto-updates to
+          # each new version. Idempotent: on subsequent runs it's already
+          # installed, so a non-zero exit here is non-fatal.
+          echo "Ensuring extension '$EXTENSION_ID' is installed in '$ADO_ORG'..."
+          if npx tfx extension install \
+            --publisher "$PUBLISHER" \
+            --extension-id "$EXTENSION_ID" \
+            --service-url "https://${ADO_ORG}.visualstudio.com" \
+            --token "$MARKETPLACE_PAT"; then
+            echo "Install/enable confirmed."
+          else
+            echo "Install returned non-zero (likely already installed) — continuing."
+          fi
+
+          echo "Waiting 90s for Marketplace async validation to settle before jobs 2 & 3 run their version check..."
+          sleep 90
+          echo "Done — ADO will auto-update to version $VSIX_VERSION."
+
       - name: Write install instructions to job summary
         env:
           VSIX_VERSION: ${{ steps.build_vsix.outputs.vsix_version }}
@@ -220,11 +281,11 @@ jobs:
           ADO_ORG:      ${{ secrets.ADO_E2E_ORG }}
         run: |
           {
-            echo "## Manual install step (≈3 min, only when testing PR code)"
+            echo "## Install (auto by default — manual steps are a fallback)"
             echo ""
             echo "**This PR built:** \`$VSIX_NAME\` (version \`$VSIX_VERSION\`, extension id \`$EXTENSION_ID\`)"
             echo ""
-            echo "If you want the ADO test pipelines (jobs 2 & 3) to actually exercise this PR's code, do the following. If you skip this step the pipelines still run, but against whatever .vsix was installed previously."
+            echo "When the \`ADO_E2E_MARKETPLACE_PAT\` secret is set, the *Publish to Marketplace* step already published, shared and installed this build, and ADO auto-updates the dev org — so jobs 2 & 3 test this PR's code automatically. The steps below are only needed if that secret is unset or the auto-publish step was skipped/failed."
             echo ""
             echo "1. **Download the .vsix** from the *Artifacts* section at the bottom of this run page (artifact: \`jfrog-ext-vsix-${{ github.run_number }}\`). It downloads as a .zip wrapper — unzip it to get the actual .vsix."
             echo "2. **Upload to your publisher** at https://marketplace.visualstudio.com/manage/publishers/${ADO_ORG}-private"


### PR DESCRIPTION
## Summary
Re-enables the fully automated e2e flow so jobs 2 & 3 always test the PR's own code:

- Adds a **Publish to Marketplace, share and install** step in Job 1. It publishes the freshly built private `.vsix`, shares it with the dev org, and installs it — after which ADO auto-updates the org to each new version.
- Fixes the versioning bug that caused this step to be removed before: the version is now `0.<run_number>.<run_attempt>`, which is strictly increasing across runs **and** re-runs. This avoids the old "version must increase" failure that made Job 1 fail and silently skip jobs 2 & 3.
- Gated on the `ADO_E2E_MARKETPLACE_PAT` secret. If it is unset, the step is a no-op and the manual artifact-upload flow still works.
- Updates the job-summary wording to describe manual upload as a fallback.

## Behavior
- Secret set → build → publish + share + install → ADO auto-updates → jobs 2 & 3 verify the version matches and run against this PR's code.
- Secret unset → build + upload artifact only (unchanged manual fallback).

## Notes
- The extension id is shared across all e2e runs, so the version must be globally monotonic; PR-number-based versions could go backwards when an older PR runs after a newer one. `run_number` is globally monotonic per workflow, `run_attempt` covers re-runs.
- The pre-existing 7-minute propagation wait + version-match guard in jobs 2 & 3 now line up with an actual publish.

## Test plan
- [ ] Label a PR "safe to test" and confirm Job 1 publishes without a version error (including on a manual "Re-run all jobs").
- [ ] Confirm jobs 2 & 3 report version MATCH and run against the new build.
- [ ] Re-run the same run and confirm no "version must increase" failure.
- [ ] Unset the secret path: confirm the step is skipped and the artifact is still produced.
